### PR TITLE
change the default app name of quantum_volume benchmark generator

### DIFF
--- a/benchmarks/quantum_volume/quantum_volume_gen.py
+++ b/benchmarks/quantum_volume/quantum_volume_gen.py
@@ -82,7 +82,7 @@ def build_model_circuits(name, n, depth, num_circ=1):
 def main():
   parser = argparse.ArgumentParser(
       description="Create randomized circuits for quantum volume analysis.")
-  parser.add_argument('--name', default='random', help='circuit name')  
+  parser.add_argument('--name', default='quantum_volume', help='circuit name')  
   parser.add_argument('-n', '--qubits', default=5, type=int, help='number of circuit qubits')
   parser.add_argument('-d', '--depth', default=5, type=int, help='SU(4) circuit depth')
   parser.add_argument('--num-circ', default=1, type=int, help='how many circuits?')    


### PR DESCRIPTION
quantum_volume_gen.py generates random_n5_d5.qasm files if --name is not specified. "random" was renamed as "quantum_volume". So, it is better to use "quantum_volume" as the default value of --name.