### PR TITLE
Resolve undefined names in quantum_volume.py

### DIFF
--- a/benchmarks/quantum_volume/quantum_volume.py
+++ b/benchmarks/quantum_volume/quantum_volume.py
@@ -110,10 +110,10 @@ def main():
         return
 
     # Save QASM representation of circuits
-    for i in range(num_circ):
-        f = open('quantum_volume_n%d_d%d_i.qasm' % (n, depth, i), 'w')
-        f.write(circuits[i].qasm())
-        f.close()
+    for i in range(args.num_circ):
+        filename = 'quantum_volume_n%d_d%d_i.qasm' % (args.qubits, args.depth, i)
+        with open(filename, 'w') as f:
+            f.write(circuits[i].qasm())
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
__num_circ__, __n__, and __depth__ are _undefined names_ in this context which will probably raise __NameError__ at runtime.  They can be resolved as was done on lines 99 and 100.  Also, used __with open() as__ to guarantee proper __file.close()__ even in the face of an Exception.

[flake8](http://flake8.pycqa.org) testing of https://github.com/Qiskit/openqasm on Python 3.7.0

$ __flake8 . --count --select=E901,E999,F821,F822,F823 --show-source --statistics__
```
./benchmarks/quantum_volume/quantum_volume.py:113:20: F821 undefined name 'num_circ'
    for i in range(num_circ):
                   ^
./benchmarks/quantum_volume/quantum_volume.py:114:53: F821 undefined name 'n'
        f = open('quantum_volume_n%d_d%d_i.qasm' % (n, depth, i), 'w')
                                                    ^
./benchmarks/quantum_volume/quantum_volume.py:114:56: F821 undefined name 'depth'
        f = open('quantum_volume_n%d_d%d_i.qasm' % (n, depth, i), 'w')
                                                       ^
3     F821 undefined name 'num_circ'
3
```