### PR TITLE
Fixed wrong formula

### DIFF
--- a/spec/qasm2.rst
+++ b/spec/qasm2.rst
@@ -240,9 +240,8 @@ All of the single-qubit unitary gates are also built in
 .. math::
 
 	U(\theta,\phi,\lambda) := R_z(\phi)R_y(\theta)R_z(\lambda) = \left(\begin{array}{cc}
-	e^{-i(\phi+\lambda)/2}\cos(\theta/2) & -e^{-i(\phi-\lambda)/2}\sin(\theta/2) \\
-	e^{i(\phi-\lambda)/2}\sin(\theta/2) & e^{i(\phi+\lambda)/2}\cos(\theta/2)
-	\end{array}\right).
+	\cos(\theta/2) & -e^{i\lambda}\sin(\theta/2) \\
+	e^{i\phi}\sin(\theta/2) & e^{i(\phi+\lambda)}\cos(\theta/2)
 
 Here :math:`R_y(\theta)=\mathrm{exp}(-i\theta Y/2)` and
 :math:`R_z(\phi)=\mathrm{exp}(-i\phi Z/2)`. This specifies any


### PR DESCRIPTION
The formula for the U gate is not right.
When trying to build the Hadamard gate as specified in the document with the (unmodified) U gate, you get a gate that is everything but the Hadamard gate.
Also, there are some incoherences that need to be reviewed (i. e.: at the start of the document, the U gate is said to be formed with 3 gates, Rz, Ry, Rz. At the end, a totally different thing is said)
Finally, if I recall well, U is not a valid instruction in OpenQASM, you need to use u1, u2 and u3. The last one is equivalent to U gate. Then, it might be needed to update the specification and the examples done at the start.

Source:
https://quantumexperience.ng.bluemix.net/proxy/tutorial/full-user-guide/002-The_Weird_and_Wonderful_World_of_the_Qubit/004-advanced_qubit_gates.html