### PR TITLE
Update teleport.qasm

### DIFF
--- a/examples/generic/teleport.qasm
+++ b/examples/generic/teleport.qasm
@@ -15,7 +15,7 @@ cx q[0],q[1];
 h q[0];
 measure q[0] -> c0[0];
 measure q[1] -> c1[0];
-if(c0==1) z q[2];
 if(c1==1) x q[2];
+if(c0==1) z q[2];
 post q[2];
 measure q[2] -> c2[0];


### PR DESCRIPTION
X and Z corrections should be interchanged, otherwise we get a MINUS (-) global phase when the final measurement result is [1, 1] (if ran with Qiskit). The circuit is correct if one used the definitions of the gates from the "pure" QASM as defined by the spec https://arxiv.org/abs/1707.03429; that's because there the Hadamard gate `h` ends up having a minus sign, i.e. `-[1 1; 1 -1]`, however Qiskit defines it "correctly" as `[1 1; 1 -1]` (ignored here the `1/\sqrt{1}`), and this causes the `-` sign.