### PR TITLE
Small changes. readme, language:version Strings/Included files 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -195,3 +195,4 @@ pip-delete-this-directory.txt
 
 # OS specific
 .DS_Store
+source/_build

--- a/README.md
+++ b/README.md
@@ -65,9 +65,7 @@ output = measure input;  // should get zero
 
 The latest version is: **3.0**. 
 
-For previous versions see 
-
-* [OpenQASM 2.0](https://arxiv.org/abs/1707.03429v2)
+For previous versions see: [2.0](https://arxiv.org/abs/1707.03429v2)
 
 ## Citation format
 

--- a/README.md
+++ b/README.md
@@ -69,7 +69,6 @@ h input;
 output = measure input;  // should get zero
 ```
 
-
 ## Citation format
 
 For research papers, we encourage authors to reference.

--- a/source/grammar/index.rst
+++ b/source/grammar/index.rst
@@ -1,6 +1,12 @@
 Grammar
 =======
 
+Grammar specification based in ANTLR_ parser generator
+
+.. _ANTLR: https://www.antlr.org/
+
+[WIP]
+
 .. literalinclude:: qasm3.g4
    :language: antlr
    :linenos:

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,5 +1,5 @@
-OpenQASM Live Specification
-===========================
+OpenQASM 3.x Live Specification 
+===============================
 
 .. toctree::
   :maxdepth: 3

--- a/source/index.rst
+++ b/source/index.rst
@@ -1,4 +1,4 @@
-OpenQASM 3.x Live Specification 
+OpenQASM 3.x Live Specification
 ===============================
 
 .. toctree::

--- a/source/intro.rst
+++ b/source/intro.rst
@@ -57,4 +57,4 @@ John Smolin[2]_, Ntwali Bashige Toussaint[3]_
 .. [1] Zurich Instruments
 .. [2] IBM Quantum
 .. [3] Zapata Computing
-.. [4] Amazon AWS
+.. [4] AWS Center for Quantum Computing

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -22,7 +22,7 @@ The first (non-comment) line of an OpenQASM program may optionally be
 indicating a major version M and minor version m. Version 3.0 is
 described in this document. Multiple occurrences of the version keyword
 are not permitted. The minor version number and decimal point are
-optional. If they are not present, they are assumed to be zero.
+optional. If they are not present, minor version number is assumed to be zero.
 
 Included files
 ==============
@@ -35,6 +35,6 @@ inserted at the location of the statement.
    // First non-comment is a version string
    OPENQASM 3.0;
 
-   #include "stdgates.qasm";
+   include "stdgates.qasm";
 
    // Rest of QASM program


### PR DESCRIPTION
readme.md:
move the Version section after the initial description of the project and "minimize" the OPENQASM 2.x visibility, adding link to the Live doc. 

Documentation
- Language>Version string : adding more clarity when the minor version is not present
- Language>Include Files: remove the "#" in the "include statement
- Grammar: Adding link to ANTLR4 base library to use the Grammar file, and mark it like "Work in Progress"
