### PR TITLE
Fix CI jobs to actually work with PRs from forks

### DIFF
--- a/.github/workflows/build-live-version.yml
+++ b/.github/workflows/build-live-version.yml
@@ -1,7 +1,7 @@
-name: Publish Live Version
+name: Build Live Version
 
 on:
-  push:
+  pull_request:
     branches: [ master ]
 
 jobs:
@@ -23,10 +23,7 @@ jobs:
       - name: Generate HTML
         run: make singlehtml
 
-      - name: Deploy 🚀
-        uses: JamesIves/github-pages-deploy-action@3.7.1
+      - uses: actions/upload-artifact@v2
         with:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          BRANCH: gh-pages
-          FOLDER: build/singlehtml
-          CLEAN: false
+          name: singlehtml
+          path: build/singlehtml


### PR DESCRIPTION
In #58 new CI jobs were added to attempt to build and publish a live
version of the docs from pull requests and merged commits with github
pages. However, this had 2 issues, the first is that the auth model in
github doesn't allow PRs from forks write access (which is a security
precaution). The second is that multiple PRs will interfere with each
other and overwrite each other if the jobs are triggered at the same
time.

This commit fixes this issue by changing the CI configuration to only
build the docs in CI and store the built documentation as a zip file
artifact that can be downloaded. While the actualy "live version"
publish job only runs post-merge.