### PR TITLE
Restore dropped \code{..} sections from TeX to RST conversion.

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -20,7 +20,7 @@ Low-level classical instructions
 Generalities
 ~~~~~~~~~~~~
 
-All types support the assignment operator . The left-hand-side (LHS) and
+All types support the assignment operator ``=``. The left-hand-side (LHS) and
 right-hand-side (RHS) of the assignment operator must be of the same
 type. For real-time values assignment is by copy of the RHS value to the
 assigned variable on the LHS.
@@ -40,10 +40,10 @@ Classical bits and registers
 
 Classical registers and bits support bitwise operators and the
 corresponding assignment operators between registers of the same size:
-and , or , xor . They support left shift and right shift by an unsigned
+and ``&``, or ``|``, xor ``^``. They support left shift ``<<`` and right shift ``>>`` by an unsigned
 integer, and the corresponding assignment operators. The shift operators
-shift bits off the end. They also support not ,  [1]_, and left and
-right circular shift, and , respectively.
+shift bits off the end. They also support not ``~``, ``popcount``[1]_, and left and
+right circular shift, ``rotl`` and ``rotr``, respectively.
 
 .. code-block:: c
 
@@ -61,8 +61,8 @@ Comparison (Boolean) Instructions
 Integers, fixed-point numbers, angles, bits, and classical registers can
 be compared (:math:`>`, :math:`>=`, :math:`<`, :math:`<=`, :math:`==`,
 :math:`!=`) and yield Boolean values. Boolean values support logical
-operators: and , or , not . The keyword tests if an integer belongs to
-an index set, for example returns if i equals 0 or 3 and otherwise.
+operators: and ``&&``, or ``||``, not ``!``. The keyword ``in`` tests if an integer belongs to
+an index set, for example ``i in {0,3}`` returns ``true`` if i equals 0 or 3 and ``false`` otherwise.
 
 .. code-block:: c
 
@@ -82,9 +82,9 @@ an index set, for example returns if i equals 0 or 3 and otherwise.
 Integers
 ~~~~~~~~
 
-Integer types support addition , subtraction , multiplication, and
-division [2]_; the corresponding assignments , , , and ; as well as
-increment and decrement .
+Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, and
+division[2]_ ``/``; the corresponding assignments ``+=``, ``-=``, ``*=``, and ``/=``; as well as
+increment ``++`` and decrement ``--``.
 
 .. code-block:: c
 
@@ -113,8 +113,8 @@ multiplication, and division and the corresponding assignment operators.
 Looping and branching
 ~~~~~~~~~~~~~~~~~~~~~
 
-The statement branches to program if the Boolean evaluates to true and
-may optionally be followed by .
+The statement ``if ( bool ) { program }`` branches to program if the Boolean evaluates to true and
+may optionally be followed by ``else { program }``.
 
 .. code-block:: c
 
@@ -130,18 +130,24 @@ may optionally be followed by .
       // do something else
    }
 
-The statement loops over integer values in the indexset, assigning them
-to . The for loop body is not permitted to modify the loop variable of
+The statement ``for name in indexset { program }`` loops over integer values in the indexset, assigning them
+to ``name``. The for loop body is not permitted to modify the loop variable of
 the indexset.
 
 .. code-block:: c
 
    int[32] b;
+   // loop over a discrete set of values
    for i in {1, 5, 10} {
        b += i;
    } // b == 16
 
-The statement executes program until the Boolean evaluates to
+   // loop over every positive number from 0 to 20 using an indexset
+   for i in [0:2:20] {
+      // do something
+   }
+
+The statement ``while ( bool ) { program }`` executes program until the Boolean evaluates to
 false [3]_. Variables in the loop condition statement may be modified
 within the while loop body.
 
@@ -161,10 +167,10 @@ within the while loop body.
        }
    }
 
-A block can be exited with the statement . The statement can appear in
+A block ``{ program }`` can be exited with the statement ``break;``. The statement ``continue;`` can appear in
 the body of a for or while loop. It returns control to the loop
-condition. The statement terminates the program. In all of the
-preceding, can also be replaced by a statement without the braces.
+condition. The statement ``end;`` terminates the program. In all of the
+preceding, ``{ program }`` can also be replaced by a statement without the braces.
 
 .. code-block:: c
 
@@ -191,7 +197,7 @@ Kernel function calls
 ---------------------
 
 Kernel functions are declared by giving their signature using the
-statement where inputs is a comma-separated list of type names and
+statement ``kernel name(inputs)-> output;`` where inputs is a comma-separated list of type names and
 output is a single type name. They can be functions of any number of
 arguments whose types correspond to the classical types of OpenQASM.
 Inputs are passed by value. They can return zero or one value whose type
@@ -201,16 +207,16 @@ The type and size of each argument must be known at compile time to
 define data flow and enable scheduling. We do not address issues such as
 how the kernel functions are defined and registered.
 
-Kernel functions are invoked using the statement The functions are not
+Kernel functions are invoked using the statement ``name(inputs) -> output;``. The functions are not
 required to be idempotent. They may change the state of the process
 providing the function. In our computational model, the kernel functions
 are assumed to run concurrently with other classical and quantum
 computations. The output of a kernel function can be assigned to a
 variable on declaration using the assignment operator rather than the
-arrow notation.
+``->`` arrow notation.
 
 .. [1]
-   computes the Hamming weight of the input register.
+   ``popcount`` computes the Hamming weight of the input register.
 
 .. [2]
    If multiplication and division instructions are not available in

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -1,7 +1,7 @@
 Comments
 ========
 
-Comments begin with a pair of forward slashes and end with a new line:
+Comments begin with a pair of forward slashes ``//`` and end with a new line:
 
 .. code-block:: c
 
@@ -18,7 +18,7 @@ A comment block begins with ``/*`` and ends with ``*/``:
 Version string
 ==============
 
-The first (non-comment) line of an OpenQASM program may optionally be
+The first (non-comment) line of an OpenQASM program may optionally be ``OPENQASM M.m;``
 indicating a major version M and minor version m. Version 3.0 is
 described in this document. Multiple occurrences of the version keyword
 are not permitted. The minor version number and decimal point are
@@ -27,8 +27,8 @@ optional. If they are not present, minor version number is assumed to be zero.
 Included files
 ==============
 
-The statement continues parsing as if the contents of the file were
-inserted at the location of the statement.
+The statement ``include "filename";`` continues parsing ``filenmae`` as if the contents of the file were
+inserted at the location of the ``include`` statement.
 
 .. code-block:: c
 

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -20,24 +20,24 @@ or “implement this gate as late as possible".
 length and stretch types
 ------------------------
 
-The type is used denote duration of time. Lengths are positive numbers
+The ``length`` type is used denote duration of time. Lengths are positive numbers
 that are manipulated at compile time. Lengths have units which can be
 any of the following:
 
--  SI units of time, such as
+-  SI units of time, such as ``ns, µs, ms, s``
 
--  Backend-dependent unit, , equivalent to the duration of one waveform
+-  Backend-dependent unit, ``dt``, equivalent to the duration of one waveform
    sample on the backend
 
 It is often useful to reference the duration of other parts of the
 circuit. For example, we may want to delay a gate for twice the duration
 of a particular sub-circuit, without knowing the exact value to which
 that duration will resolve. Alternatively, we may want to calibrate a
-gate using some pulses, and use its duration as a new in order to delay
-other parts of the circuit. The intrinsic function can be used for this
+gate using some pulses, and use its duration as a new ``length`` in order to delay
+other parts of the circuit. The ``lengthof()`` intrinsic function can be used for this
 type of referential timing.
 
-Below are some examples of values of type .
+Below are some examples of values of type ``length``.
 
 .. code-block:: c
 
@@ -50,7 +50,7 @@ Below are some examples of values of type .
        // dynamic length, referencing a box within its context
        length d = lengthof(box);
 
-We further introduce a type which is a sub-type of . Stretchable lengths
+We further introduce a ``stretch`` type which is a sub-type of ``length``. Stretchable lengths
 have variable non-negative length that is permitted to grow as necessary
 to satisfy constraints. Stretch variables are resolved at compile time
 into target-appropriate durations that satisfy a user’s specified design
@@ -58,9 +58,9 @@ intent.
 
 Instructions whose duration is specified in this way become “stretchy",
 meaning they can extend beyond their “natural length" to fill a span of
-time. Stretchy s are the most obvious use case, but this can be extended
+time. Stretchy ``delay``'s are the most obvious use case, but this can be extended
 to other instructions too, e.g. rotating a spectator qubit while another
-gate is in progress. Similarly, a whose definition contains stretchy
+gate is in progress. Similarly, a ``gate`` whose definition contains stretchy
 delays will be perceived as a stretchy gate by other parts of the
 program.
 
@@ -96,10 +96,10 @@ the stretchy delays (Figure `[fig:alignment] <#fig:alignment>`__\ b):
 
 [fig:leftalignresolved]
 
-Lastly, we distinguish different “orders" of stretch via types, where N
-is an integer between 0 to 255. is an alias for the regular . Higher
+Lastly, we distinguish different “orders" of stretch via ``stretchN`` types, where N
+is an integer between 0 to 255. ``stretch0`` is an alias for the regular ``stretch``. Higher
 order stretches will suppress lower order stretches whenever they appear
-in the same scope on the same qubits. A keyword is defined as an
+in the same scope on the same qubits. A ``stretchinf`` keyword is defined as an
 infinitely stretchable length. It will always take precedence, and will
 not changed if arithmetic operations are done on it. This is most useful
 as a “don’t care" mechanism to specify delays that will just fill
@@ -117,7 +117,7 @@ whatever gap is present.
        // other instruction don't care about the value to which this resolves.
        delay[stretchinf];
 
-The concepts of and are inspired by the concept of “boxes and glues" in
+The concepts of ``box`` and ``stretch`` are inspired by the concept of “boxes and glues" in
 the TeX language :cite:`knuth1984texbook`. This similarity
 is natural; TeXaims to resolve the spacing between characters in order
 to typeset a page, and the size of characters depend on the backend
@@ -126,7 +126,7 @@ instructions in order to meet high-level design intents, while the true
 length of operations depend on the backend and compilation context.
 There are however some key differences. Quantum operations can be
 non-local, meaning the lengths set on one qubit can have side effects on
-other qubits. The definition of -type variables and ability to define
+other qubits. The definition of ``length``-type variables and ability to define
 multi-qubit stretches is intended to alleviate potential problems from
 these side effects. Also contrary to TeX, we prohibit overlapping gates.
 
@@ -147,29 +147,29 @@ including stretches, will be resolved to constants.
        // stretchy length with backtracking by up to half b
        length e = -0.5 * b + c
 
-Delays (and other lengthed instructions)
+Delays (and other lengthened instructions)
 ----------------------------------------
 
-OpenQASM and OpenPulse have a instruction, whose duration is defined by
-a . If the length passed to the delay contains stretch, it will become a
+OpenQASM and OpenPulse have a ``delay`` instruction, whose duration is defined by
+a ``length``. If the length passed to the delay contains stretch, it will become a
 stretchy delay. We use square bracket notation to pass these length
 parameters, to distinguish them from regular parameters (the compiler
 will resolve these square-bracket parameters when resolving timing ).
 
-Even though a instruction implements the identity channel in the ideal
-case, it is intended to provide explicit timing. Therefore an explicit
+Even though a ``delay`` instruction implements the identity channel in the ideal
+case, it is intended to provide explicit timing. Therefore an explicit ``delay``
 instruction will prevent commutation of gates that would otherwise
 commute. For example in
 Figure `[fig:delaycommute] <#fig:delaycommute>`__\ a, there will be an
-implicit delay between the ‘‘ gates on qubit 0. However, the ‘‘ gate is
+implicit delay between the ``cx`` gates on qubit 0. However, the ``rz`` gate is
 still free to commute on that qubit, because the delay is implicit. Once
 the delay becomes explicit (perhaps at lower stages of compilation),
 gate commutation is prohibited
 (Figure `[fig:delaycommute] <#fig:delaycommute>`__\ b).
 
 Instructions other than delay can also have variable duration, if they
-are explicitly defined as such. They can be called by passing a valid as
-their duration. Consider for example a rotation called that is applied
+are explicitly defined as such. They can be called by passing a valid ``length`` as
+their duration. Consider for example a rotation called ``rotary`` that is applied
 for the entire duration of some other gate.
 
 .. code-block:: c
@@ -179,11 +179,11 @@ for the entire duration of some other gate.
        rotary(amp)[250ns] q;   // square brackets indicates duration
        rotary(amp)[a] q;       // a rotation that will stretch as needed
 
-A multi-qubit instruction is *not* equivalent to multiple single-qubit
-instructions. Instead a multi-qubit delay acts as a synchronization
+A multi-qubit ``delay`` instruction is *not* equivalent to multiple single-qubit
+``delay`` instructions. Instead a multi-qubit delay acts as a synchronization
 point on the qubits, where the delay begins from the latest non-idle
 time across all qubits, and ends simultaneously across all qubits. For
-this reason, a instruction is exactly equivalent to a of a length zero
+this reason, a ``barrier`` instruction is exactly equivalent to a ``delay`` of a length zero
 on the qubits involved.
 
 .. code-block:: c
@@ -193,7 +193,7 @@ on the qubits involved.
        // delay for 200 samples starting from the end of the longest cx
        delay[200dt] q[0:3];
 
-A can be composed of positive or negative natural length, and of
+A ``length`` can be composed of positive or negative natural length, and of
 positive stretch. After resolving the stretch, the instruction must end
 up with non-negative duration.
 
@@ -227,7 +227,7 @@ to properly take into account the finite length of each gate.
 Boxed expressions
 -----------------
 
-We introduce a expression for scoping a particular part of the circuit.
+We introduce a ``box`` expression for scoping a particular part of the circuit.
 A boxed subcircuit can never be inlined (until target code generation
 time), and optimizations across the boundary of a box are forbidden. The
 contents inside the box can be optimized. The contents around the box
@@ -236,11 +236,11 @@ box by knowing the unitary implemented by the box. Delays that are
 within a box are implementation details of the box; they are invisible
 to the outside scope and therefore do not prevent commutation.
 
-We introduce a expression for labeling a box. We primarily use this to
+We introduce a ``boxas`` expression for labeling a box. We primarily use this to
 later refer to the length of this box. Boxed expressions are good for
 this because their contents are isolated and cannot be combined with
 gates outside the box. Therefore, no matter how the contents of the box
-get optimized, the has a well-defined meaning.
+get optimized, the ``lengthof(boxlabel`` has a well-defined meaning.
 
 .. code-block:: c
 
@@ -251,7 +251,7 @@ get optimized, the has a well-defined meaning.
        delay[length(mybox)] q[2], q[3];
        cx q[2], q[3];
 
-We introduce a expression. The contents of it will be boxed, and in
+We introduce a ``boxto`` expression. The contents of it will be boxed, and in
 addition a total duration will be assigned to the box. This is useful
 for conditionals where the box will declare a hard deadline. The natural
 length of the box must be smaller than the declared boxto duration,
@@ -272,8 +272,8 @@ length and the natural length.
 Barrier instruction
 -------------------
 
-The instruction of OpenQASM 2 prevents commutation and gate reordering
-on a set of qubits across its source line. The syntax is and can be seen
+The ``barrier`` instruction of OpenQASM 2 prevents commutation and gate reordering
+on a set of qubits across its source line. The syntax is ``barrier qregs|qubits;`` and can be seen
 in the following example
 
 .. code-block:: c
@@ -287,5 +287,5 @@ in the following example
    cx r[0], r[1];
 
 This will prevent an attempt to combine the CNOT gates but will not
-constrain the pair of gates, which might be executed before or after the
+constrain the pair of ``h s[0];`` gates, which might be executed before or after the
 barrier, or cancelled by a compiler.

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -32,16 +32,14 @@ gate
    0 & 0 & 1 & 0 \\
    0 & 1 & 0 & 0 \end{array}\right)
 
-called the controlled-NOT gate. The statement describes a CNOT gate that
-flips the target qubit if and only if the control qubit is one. The
-arguments cannot refer to the same qubit. If and are quantum registers
-*with the same size*, the statement means apply for each index into
-register . If instead, is a qubit and is a quantum register, the
-statement means apply for each index into register . Finally, if is a
-quantum register and is a qubit, the statement means apply for each
-index into register .
-
-.
+called the controlled-NOT gate. The statement ``CX a, b;`` describes a CNOT gate that
+flips the target qubit ``b`` if and only if the control qubit ``a`` is one. The
+arguments cannot refer to the same qubit. For convenience, gates automatically broadcast over registers. If ``a`` and ``b`` are quantum registers
+*with the same size*, the statement ``CX a, b;`` means apply ``CX a[j], b[j];`` for each index ``j`` into
+register ``a``. If instead ``a`` is a qubit and ``b`` is a quantum register, the
+statement means apply ``CX a, b[j]`` for each index ``j`` into register ``b``. Finally, if ``a`` is a
+quantum register and ``b`` is a qubit, the statement means apply ``CX a[j], b;`` for each
+index ``j`` into register ``a``.
 
 All of the single-qubit unitary gates are also built-in and
 parameterized as
@@ -53,17 +51,21 @@ parameterized as
    e^{i(\phi-\lambda)/2}\sin(\theta/2) & e^{i(\phi+\lambda)/2}\cos(\theta/2) \end{array}\right).
 
 Here :math:`R_y(\theta)=\mathrm{exp}(-i\theta Y/2)` and
-:math:`R_z(\phi)=\mathrm{exp}(-i\theta Z/2)`. When is a quantum
-register, the statement means apply for each index into register . The
+:math:`R_z(\phi)=\mathrm{exp}(-i\theta Z/2)`. When ``a`` is a quantum
+register, the statement ``U(θ, ϕ, λ) a;`` means apply ``U(θ, ϕ, λ) a[j];`` for each index ``j`` into register ``a``. The
 values :math:`\theta\in [0,2\pi)`, :math:`\phi\in [0,2\pi)`, and
 :math:`\lambda\in
 [0,2\pi)` in this base gate are angles whose precision is implementation
 dependent [1]_. This specifies any element of :math:`SU(2)` up to a
-global phase. For example, applies a Hadamard gate to qubit .
+global phase. For example ``U(π/2, 0, π) q[0];``, applies a Hadamard gate to qubit ``q[0]``.
 
 Finally, a built-in global phase gate allows the inclusion of arbitrary
-global phase on circuits. adds a global phase of :math:`e^{i\gamma}` to
+global phase on circuits. ``gphase(γ);`` adds a global phase of :math:`e^{i\gamma}` to
 the circuit. e.g.:
+
+.. code-block:: c
+   gphase(0.5*γ)
+
 
 .. _sec:macros:
 
@@ -87,9 +89,9 @@ corresponding OpenQASM code is
    }
    cphase(π / 2) q[0], q[1];
 
-Note that this definition does not imply that must be implemented with
+Note that this definition does not imply that ``cphase`` must be implemented with
 this series of gates. Rather, we have specified the unitary
-transformation that corresponds to the symbol . The particular
+transformation that corresponds to the symbol ``cphase``. The particular
 implementation is up to the compiler, given information about the basis
 gate set supported by a particular target.
 
@@ -103,12 +105,12 @@ In general, new gates are defined by statements of the form
      body
    }
 
-where the optional parameter list is a comma-separated list of variable
-parameters, and the argument list is a comma-separated list of qubit
+where the optional parameter list ``params`` is a comma-separated list of variable
+parameters, and the argument list ``qargs`` is a comma-separated list of qubit
 arguments. The parameters are identifiers with angular types and default
 to 32-bits. The qubit arguments are identifiers. If there are no
 variable parameters, the parentheses are optional. At least one qubit
-argument is required. The arguments in cannot be indexed within the body
+argument is required. The arguments in ``qargs`` cannot be indexed within the body
 of the gate definition.
 
 .. code-block:: c
@@ -125,14 +127,13 @@ of the gate definition.
    }
 
 Only built-in gate statements, calls to previously defined gates, and
-timing directives can appear in . For example, it is not valid to
+timing directives can appear in ``body``. For example, it is not valid to
 declare a classical register in a gate body. The statements in the body
 can only refer to the symbols given in the parameter or argument list,
 and these symbols are scoped only to the subroutine body. An empty body
 corresponds to the identity gate. Gates must be declared before use and
-cannot call themselves. The statement applies the gate, and the variable
-parameters are given as angular types or in-place constant parameter
-expressions which are cast to angles. The gate can be applied to any
+cannot call themselves. The statement ``name(params) qargs;`` applies the gate, and the variable
+parameters ``params`` can have any numeric type. The gate can be applied to any
 combination of qubits and quantum registers *of the same size* as shown
 in the following example. The quantum circuit given by
 
@@ -151,6 +152,10 @@ in the following example. The quantum circuit given by
 
 has a second-to-last line that means
 
+.. code-block:: c
+
+   // FIXME: insert translation of algorithmic block from TeX source.
+
 We provide this so that user-defined gates can be applied in parallel
 like the built-in gates.
 
@@ -162,19 +167,32 @@ A gate modifier is a keyword that applies to a gate. A modifier
 on the same or larger Hilbert space. We include modifiers in OpenQASM
 both for programming convenience and compiler analysis.
 
-The modifier replaces its gate argument :math:`U` with its inverse
+The modifier ``inv @`` replaces its gate argument :math:`U` with its inverse
 :math:`U^\dagger`. The inverse of any gate can be defined recursively by
 reversing the order of the gates in its definition and replacing each of
-those with their inverse. The base case is given by replacing with and
-by .
+those with their inverse. The base case is given by replacing ``inv @ CX`` with ``CX`` and
+``inv @ U(θ, ϕ, λ)`` by ``U(-θ, -λ, -ϕ)``.
 
-The modifier replaces its gate argument :math:`U` by its :math:`k`\ th
+.. code-block:: c
+
+   gate rzm(theta) q1 {
+       inv @ rzp(theta) q1;
+   }
+
+The modifier ``pow[k] @`` replaces its gate argument :math:`U` by its :math:`k`\ th
 power :math:`U^k` for some positive integer :math:`k` (not necessarily
 constant). Such a gate can be trivially defined as :math:`k` repetitions
 of the original gate, although more efficient implementations may be
 possible.
 
-The modifier replaces its gate argument :math:`U` by a
+.. code-block:: c
+
+   // define x as sqrt(x)
+   gate x q1 {
+       pow[2] @ sx q1;
+   }
+
+The modifier ``ctrl @`` replaces its gate argument :math:`U` by a
 controlled-:math:`U` gate. The new control qubit is prepended to the
 argument list for the controlled-:math:`U` gate. The modified gate does
 not use any additional scratch space. A target may or may not be able to
@@ -182,8 +200,8 @@ execute the gate without further compilation.
 
 .. code-block:: c
 
-   // Define a controlled Rz operation using the ctrl gatemodifier.
-   gate crz(angle[20]: θ) q1, q2 {
+   // Define a controlled Rz operation using the ctrl gate modifier.
+   gate crz(θ) q1, q2 {
        ctrl @ U(θ, 0, 0) q1, q2;
    }
 

--- a/source/language/insts.rst
+++ b/source/language/insts.rst
@@ -6,7 +6,7 @@ This sections describes built-in non-unitary operations.
 Initialization
 --------------
 
-The statement resets a qubit or quantum register to the state
+The statement ``reset qubit|qubit[];`` resets a qubit or quantum register to the state
 :math:`|0\rangle`. This corresponds to a partial trace over those qubits
 (i.e. discarding them) before replacing them with
 :math:`|0\rangle\langle 0|`. Reset is shown in
@@ -15,26 +15,26 @@ Fig. `[fig:prepare] <#fig:prepare>`__.
 .. code-block:: c
 
    // Initialize and reset an array of 10 qubits
-   qubit[10] qubits;
+   qubit qubits[10];
    reset qubits;
 
 Measurement
 -----------
 
-The statement measures the qubit(s) in the :math:`Z`-basis and assigns
+The statement ``bit|bit[] = measure qubit|qreg;`` measures the qubit(s) in the :math:`Z`-basis and assigns
 the measurement outcome(s) to the target bit(s). For backwards
-compatibility this is equivalent to which is also supported. Measurement
+compatibility this is equivalent to ``measure qubit|qubit[] -> bit|bit[];`` which is also supported. Measurement
 corresponds to a projection onto one of the eigenstates of :math:`Z`,
 and qubit(s) are immediately available for further quantum computation.
 Both arguments must be register-type, or both must be bit-type. If both
-arguments are register-type and have the same size, the statement
-broadcasts to for each index into register . Measurement is shown in
+arguments are register-type and have the same size, the statement  ``b = measure a;``
+broadcasts to ``b[j] = measure a[j];`` for each index ``j`` into register ``a``. Measurement is shown in
 Fig. `[fig:measure] <#fig:measure>`__.
 
 .. code-block:: c
 
    // Initialize, flip and measure an array of 10 qubits
-   qubit[10] qubits;
+   qubit qubits[10];
    bit[10] bits;
    x qubits;
    bits = measure qubits;

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -21,8 +21,8 @@ will define a textualized representation of one such grammar, OpenPulse.
 Here we restrict ourselves to defining the necessary interfaces within
 OpenQASM to these pulse-level definitions of gates and measurement.
 
-The entry point to such gate and measurement definitions is the keyword
-analogous to the keyword, but where the body specifies a pulse-level
+The entry point to such gate and measurement definitions is the ``defcal`` keyword
+analogous to the ``gate`` keyword, but where the ``defcal`` body specifies a pulse-level
 instruction sequence on *physical* qubits, e.g.
 
 .. code-block:: c
@@ -72,23 +72,23 @@ the most specific definition found for a given operation. Thus, given,
 the operation ``rx(pi/2) %0`` would match to (3), ``rx(pi) %0`` would
 match (2), ``rx(pi/2) %1`` would match (1).
 
-Users specify the grammar used inside blocks with a declaration, or by
-an optional grammar string in a definition, e.g.
+Users specify the grammar used inside ``defcal`` blocks with a ``defcalgrammar "name"`` declaration, or by
+an optional grammar string in a ``defcal`` definition, e.g.
 
 .. code-block:: c
 
    defcalgrammar "openpulse";
    defcal "openpulse" measure %q -> bit { ... }
 
-are two equivalent ways to specify that the definition uses the grammar.
+are two equivalent ways to specify that the ``measure`` definition uses the ``"openpulse"`` grammar.
 
-Note that and communicate orthogonal information to the compiler. s
+Note that ``defcal`` and ``gate`` communicate orthogonal information to the compiler. ``gate``'s
 define unitary transformation rules to the compiler. The compiler may
 freely invoke such rules on operations while preserving the structure of
-a circuit as a collection of s and s. The declarations instead define
-elements of a symbol lookup table. As soon as the compiler replaces a
-with a definition, we have changed the fundamental structure of the
-circuit. Most of the time symbols in the table will also have
-corresponding definitions. However, if a userprovides a for a symbol
-without a corresponding , then we treat such operations like the gates
+a circuit as a collection of ``gate``'s and ``subroutine``'s. The ``defcal`` declarations instead define
+elements of a symbol lookup table. As soon as the compiler replaces a ``gate``
+with a ``defcal`` definition, we have changed the fundamental structure of the
+circuit. Most of the time symbols in the ``defcal`` table will also have
+corresponding ``gate`` definitions. However, if a user provides a ``defcal`` for a symbol
+without a corresponding ``gate``, then we treat such operations like the ``opaque`` gates
 of prior versions of OpenQASM.

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -1,17 +1,22 @@
 Subroutines
 ===========
 
-Subroutines are declared using the statement . Zero or more quantum bits
-and registers are passed to the subroutine by reference or name in .
-Classical types are passed by value in . The subroutines return up to
+Subroutines are declared using the statement ``def name(parameters) qargs -> output { body }``.
+Zero or more quantum bits
+and registers are passed to the subroutine by reference or name in ``qargs``.
+Classical types are passed by value in ``parameters``. The subroutines return up to
 one classical type. All arguments are declared together with their type,
-for example would define a quantum bit argument named . The output of a
+for example ``qubit: ancilla`` would define a quantum bit argument named ``ancilla``. The output of a
 subroutine can be assigned to a variable on declaration using the
-assignment operator rather than the arrow notation.
+assignment operator rather than the ``->`` arrow notation.
 
 Using subroutines, we can define an X-basis measurement with the program
-. We can also define more general classes of single-qubit measurements
-as . The type declarations are necessary if we want to mix qubit and
+``def xmeasure qubit:q -> bit { h q; return measure q; }``.
+We can also define more general classes of single-qubit measurements
+as
+``def pmeasure(angle[32]: theta) qubit:q -> bit { rz(theta) q; h q; return
+measure q; }``.
+The type declarations are necessary if we want to mix qubit and
 register arguments. For example, we might define a parity check
 subroutine that takes qubits and registers
 

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -150,10 +150,10 @@ vendors may not support manipulating these values at run-time.
 Fixed-point angles
 ~~~~~~~~~~~~~~~~~~
 
-Fixed-point angles are interpreted as :math:`2\pi` times a 0:1:n-1
+Fixed-point angles are interpreted as 2π times a 0:1:n-1
 fixed-point number. This represents angles in the interval
 :math:`[0,2\pi)` up to an error :math:`\epsilon\leq \pi/2^{n-1}` modulo
-:math:`2\pi`. The statement ``angle[size] name;`` declares an n-bit angle. OpenQASM3
+2π. The statement ``angle[size] name;`` declares an n-bit angle. OpenQASM3
 introduces this specialized type because of the ubiquity of this angle
 representation in phase estimation circuits and numerically controlled
 oscillators found in hardware platform. Note that defining gate
@@ -191,7 +191,7 @@ declaration, they take their assigned value and cannot be redefined
 within the same scope. These are constructed using an in-fix notation
 and scientific calculator features such as scientific notation, real
 arithmetic, logarithmic, trigonometric, and exponential functions
-including ``sqrt``, ``floor``, ``ceiling``, ``log``, ``pow``, ``div``, ``mod`` and the built-in constant :math:`\pi`. The
+including ``sqrt``, ``floor``, ``ceiling``, ``log``, ``pow``, ``div``, ``mod`` and the built-in constant π. The
 statement ``const name = expression;`` defines a new constant. The expression on the right hand side
 has a similar syntax as OpenQASM 2 parameter expressions; however,
 previously defined constants can be referenced in later variable
@@ -226,9 +226,9 @@ namespace are listed in table `1 <#tab:real-constants>`__.
       +-------------------------------+--------------+--------------+---------------------+
       | Constant                      | Alphanumeric | Unicode      | Approximate Base 10 |
       +-------------------------------+--------------+--------------+---------------------+
-      | (r)1-1(lr)2-2(rl)3-3(l)4-4 Pi | pi           | :math:`\pi`  | 3.1415926535...     |
+      | Pi                            | pi           | π            | 3.1415926535...     |
       +-------------------------------+--------------+--------------+---------------------+
-      | Tau                           | tau          | :math:`\tau` | 6.283185...         |
+      | Tau                           | tau          | τ            | 6.283185...         |
       +-------------------------------+--------------+--------------+---------------------+
       | Euler’s number                | euler_gamma  | :math:`e`    | 2.7182818284...     |
       +-------------------------------+--------------+--------------+---------------------+

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -12,17 +12,17 @@ Variable identifiers must begin with a letter [A-Za-z], an underscore, a
 percent sign, or an element from the Unicode character categories
 Lu/Ll/Lt/Lm/Lo/NI :cite:`noauthorUnicodeNodate`.
 Continuation characters may contain numbers. Variable identifiers may
-not override a reserved identifier. 
+not override a reserved identifier.
 
 In addition to being assigned values within a program, all of the classical
 types can be initialized on declaration. Multiple comma-separated declarations
-can occur after the typename with optional assignment on declaration for each. 
-Any classical variable or Boolean that is not explicitly initialized is 
-undefined. Classical types can be mutually cast to one another using the 
-typename. 
+can occur after the typename with optional assignment on declaration for each.
+Any classical variable or Boolean that is not explicitly initialized is
+undefined. Classical types can be mutually cast to one another using the
+typename.
 
-We use the notation to denote the width and precision of fixed point numbers, 
-where is the number of sign bits, is the number of integer bits, and is the
+We use the notation ``s:m:f`` to denote the width and precision of fixed point numbers,
+where ``s`` is the number of sign bits, ``m`` is the number of integer bits, and ``f`` is the
 number of fractional bits. It is necessary to specify low-level
 classical representations since OpenQASM operates at the intersection of
 gates/analog control and digital feedback and we need to be able to
@@ -35,23 +35,23 @@ Quantum types
 Qubits
 ~~~~~~
 
-There is a quantum bit () type that is interpreted as a reference to a
+There is a quantum bit (``qubit``) type that is interpreted as a reference to a
 two-level subsystem of a quantum state. Quantum registers are static
-arrays of qubits that cannot be dynamically resized. The statement
-declares a reference to a quantum bit. The statement or declares a
-quantum register with the given name identifier. The keyword is included
+arrays of qubits that cannot be dynamically resized. The statement ``qubit name;``
+declares a reference to a quantum bit. The statement ``qreg name[size];`` or ``qubit name[size];`` declares a
+quantum register with the given name identifier. The keyword ``qreg`` is included
 for backwards compatibility and will be removed in the future. Sizes
-must always be constant positive integers. The label refers to a qubit
+must always be constant positive integers. The label ``name[j]`` refers to a qubit
 of this register, where
 :math:`j\in \{0,1,\dots,\mathrm{size}(\mathrm{name})-1\}` is an integer.
-Qubits are initially in an undefined state. A quantum operation is one
+Qubits are initially in an undefined state. A quantum ``reset`` operation is one
 way to initialize qubit states.
 
 All qubits are global variables.
 Qubits cannot be declared within gates or subroutines. This simplifies OpenQASM
 significantly since there is no need for quantum memory management.
 However, it also means that users or compiler have to explicitly manage
-the quantum memory. 
+the quantum memory.
 
 Physical Qubits
 ~~~~~~~~~~~~~~~
@@ -69,8 +69,8 @@ circuits.
    qubit γ;
    // Declare a qubit array with 20 qubits
    qubit qubit_array[20];
-   // Declare usage of physical qubit 0
-   qubit %0;
+   // CNOT gate between physical qubits 0 and 1
+   CX %0, %1;
 
 Classical types
 ---------------
@@ -81,9 +81,9 @@ Classical bits and registers
 There is a classical bit type that takes values 0 or 1. Classical
 registers are static arrays of bits. The classical registers model part
 of the controller state that is exposed within the OpenQASM program. The
-statement declares a classical bit, and or declares an array of bits
-(register). The keyword is deprecated and will be removed in the future.
-The label refers to a bit of this register, where :math:`j\in
+statement ``bit name;`` declares a classical bit, and ``creg name[size];`` or ``bit name[size];`` declares an array of bits
+(register). The keyword ``creg`` is deprecated and will be removed in the future.
+The label ``name[j]`` refers to a bit of this register, where :math:`j\in
 \{0,1,\dots,\mathrm{size}(\mathrm{name})-1\}` is an integer. For
 convenience, classical registers can be assigned a text string
 containing zeros and ones of the same length as the size of the
@@ -101,40 +101,44 @@ bit is on the right.
 Integers
 ~~~~~~~~
 
-There are n-bit signed and unsigned integers. The statements and declare
+There are n-bit signed and unsigned integers. The statements ``int[size] name;`` and ``uint[size] name;`` declare
 signed 1:n-1:0 and unsigned 0:n:0 integers of the given size. The sizes
 are always explicitly part of the type; there is no implicit width for
 classical types in OpenQASM. Because register indices are integers, they
 can be cast from classical registers containing measurement outcomes and
 may only be known at run time. An n-bit classical register containing
 bits can also be reinterpreted as an integer, and these types can be
-mutually cast to one another using the type name, e.g. . As noted, this
-conversion will be done assuming little-endian bit ordering.
+mutually cast to one another using the type name, e.g. ``int[16](c)``. As noted, this
+conversion will be done assuming little-endian bit ordering. The example
+below demonstrates how to declare, assign and cast integer types amongst
+one another.
 
 .. code-block:: c
 
    // Declare a 32-bit unsigned integer
-   uint[32] my_uint;
-   // Declare a 32 bit signed integer
-   int[32] my_int;
+   uint[32] my_uint = 10;
+   // Declare a 16 bit signed integer
+   int[16] my_int;
+   my_int = int[16](my_uint);
 
 Signed fixed-point numbers
 ~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-There are fixed-point numbers with integer bits, fractional bits, and 1
-sign bit. The statement declares a fixed-point number.
+There are ``1:m:f`` fixed-point numbers with ``m`` integer bits, ``f`` fractional bits, and 1
+sign bit. The statement ``fixed[m, f] name;`` declares a ``1:m:f`` fixed-point number.
 
 .. code-block:: c
 
    // Declare a 32-bit fixed point number.
    // The number is signed, has 7 integer bits
-   // and 24 fractional bits.
-   fixed[7, 24] my_fixed;
+   // and 24 fractional bits. The decimal number
+   // assignment is implicitly cast.
+   fixed[7, 24] my_fixed = -7.0625;
 
 Floating point numbers
 ~~~~~~~~~~~~~~~~~~~~~~
 
-IEEE 754 floating point registers may be declared with , where would
+IEEE 754 floating point registers may be declared with ``float[size] name;``, where ``float[64]`` would
 indicate a standard double-precision float. Note that some hardware
 vendors may not support manipulating these values at run-time.
 
@@ -149,23 +153,26 @@ Fixed-point angles
 Fixed-point angles are interpreted as :math:`2\pi` times a 0:1:n-1
 fixed-point number. This represents angles in the interval
 :math:`[0,2\pi)` up to an error :math:`\epsilon\leq \pi/2^{n-1}` modulo
-:math:`2\pi`. The statement declares an n-bit angle. OpenQASM3
+:math:`2\pi`. The statement ``angle[size] name;`` declares an n-bit angle. OpenQASM3
 introduces this specialized type because of the ubiquity of this angle
 representation in phase estimation circuits and numerically controlled
 oscillators found in hardware platform. Note that defining gate
-parameters with types may be necessary for those parameters to be
+parameters with ``angle`` types may be necessary for those parameters to be
 compatible with run-time values on some platforms.
 
 .. code-block:: c
 
-   // Declare an angle with 20 bits of precision
-   angle[20] my_angle;
+   // Declare an angle with 20 bits of precision and assign it a value of π/2
+   angle[20] my_angle = π / 2;
+   float[32] float_pi = π;
+   // equivalent to pi_by_2 up to rounding errors
+   angle[20](float_pi / 2);
 
 Boolean types
 ~~~~~~~~~~~~~
 
-There is a Boolean type that takes values or . Qubit measurement results
-can be converted from a classical type to a Boolean using , where 1 will
+There is a Boolean type ``bool name;`` that takes values ``true`` or ``false``. Qubit measurement results
+can be converted from a classical ``bit`` type to a Boolean using ``bool(c)``, where 1 will
 be true and 0 will be false.
 
 .. code-block:: c
@@ -184,8 +191,8 @@ declaration, they take their assigned value and cannot be redefined
 within the same scope. These are constructed using an in-fix notation
 and scientific calculator features such as scientific notation, real
 arithmetic, logarithmic, trigonometric, and exponential functions
-including , , , , , , and the built-in constant :math:`\pi`. The
-statement defines a new constant. The expression on the right hand side
+including ``sqrt``, ``floor``, ``ceiling``, ``log``, ``pow``, ``div``, ``mod`` and the built-in constant :math:`\pi`. The
+statement ``const name = expression;`` defines a new constant. The expression on the right hand side
 has a similar syntax as OpenQASM 2 parameter expressions; however,
 previously defined constants can be referenced in later variable
 declarations. Real constants are compile-time constants, allowing the
@@ -232,10 +239,10 @@ Types related to timing
 length
 ~~~~~~
 
-We introduce a type and several keywords to express lengths of time.
-Lengths are positive numbers with a unit of time. are used for SI time
-units. is a backend-dependent unit equivalent to one waveform sample on
-the backend. is an intrinsic function used to reference the duration of
+We introduce a ``length`` type and several keywords to express lengths of time.
+Lengths are positive numbers with a unit of time. ``ns, μs, ms, s`` are used for SI time
+units. ``dt`` is a backend-dependent unit equivalent to one waveform sample on
+the backend. ``lengthof()`` is an intrinsic function used to reference the duration of
 another part of the program or the duration of a calibrated gate.
 
 .. code-block:: c
@@ -246,12 +253,12 @@ another part of the program or the duration of a calibrated gate.
 stretch
 ~~~~~~~
 
-We further introduce a type which is a sub-type of . Stretchable lengths
+We further introduce a ``stretch`` type which is a sub-type of ``length``. Stretchable lengths
 have variable non-negative length that is permitted to grow as necessary
 to satisfy constraints. Stretch variables are resolved at compile time
 into target-appropriate durations that satisfy a user’s specified design
-intent. We distinguish different “orders" of stretch via types, where N
-is an integer between 0 to 255. is an alias for the regular . At the
+intent. We distinguish different “orders" of stretch via ``stretchN`` types, where N
+is an integer between 0 to 255. ``stretch0`` is an alias for the regular ``stretch``. At the
 timing resolution stage of the compiler, higher order stretches will
 suppress lower order stretches whenever they appear in the same scope on
 the same qubits.
@@ -259,10 +266,15 @@ the same qubits.
 Aliasing
 --------
 
-The keyword allows quantum bits and registers to be referred to by
-another name as long as the alias is in scope. For example, creates a
-new reference to the last 4 qubits of the register . The qubit refers to
-the qubit .
+The ``let`` keyword allows quantum bits and registers to be referred to by
+another name as long as the alias is in scope.
+
+.. code-block:: c
+
+  qubit q[5];
+  // myreg[0] refers to the qubit q[1]
+  let myreg = q[1:4];
+
 
 Register concatenation and slicing
 ----------------------------------
@@ -271,7 +283,7 @@ Two or more registers of the same type (i.e. classical or quantum) can
 be concatenated to form a register of the same type whose size is the
 sum of the sizes of the individual registers. The concatenated register
 is a reference to the bits or qubits of the original registers. The
-statement denotes the concatenation of registers. A register cannot
+statement ``a || b`` denotes the concatenation of registers ``a`` and ``b``. A register cannot
 be concatenated with any part of itself.
 
 Classical and quantum registers can be indexed in a way that selects a
@@ -282,7 +294,7 @@ cannot be indexed by an empty index set.
 
 An index set can be specified by a single unsigned integer, a
 comma-separated list of unsigned integers ``a,b,c,…``, or a range. A
-range is written as or where , , and are integers (signed or unsigned).
+range is written as ``a:b`` or ``a:c:b`` where ``a``, ``b``, and ``c`` are integers (signed or unsigned).
 The range corresponds to the set :math:`\{a, a+c, a+2c, \dots, a+mc\}`
 where :math:`m` is the largest integer such that :math:`a+mc\leq b` if
 :math:`c>0` and :math:`a+mc\geq b` if :math:`c<0`. If :math:`a=b` then


### PR DESCRIPTION
The conversion through pandoc dropped some `\code{}` sections. This PR should restore all of them. The sections reviewed are:

* `gates`
* `types`
* `insts`
* `classical`
* `subroutines`
* `pulses`
* `delays`