### PR TITLE
Fix typos I found while reading OpenQASM 3.0 spec

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
 sphinx
-sphinxcontrib-bibtex
+sphinxcontrib-bibtex<2.0.0
 pylint

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -42,7 +42,7 @@ Classical registers and bits support bitwise operators and the
 corresponding assignment operators between registers of the same size:
 and ``&``, or ``|``, xor ``^``. They support left shift ``<<`` and right shift ``>>`` by an unsigned
 integer, and the corresponding assignment operators. The shift operators
-shift bits off the end. They also support not ``~``, ``popcount``[1]_, and left and
+shift bits off the end. They also support not ``~``, ``popcount`` [1]_, and left and
 right circular shift, ``rotl`` and ``rotr``, respectively.
 
 .. code-block:: c
@@ -83,7 +83,7 @@ Integers
 ~~~~~~~~
 
 Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, and
-division[2]_ ``/``; the corresponding assignments ``+=``, ``-=``, ``*=``, and ``/=``; as well as
+division [2]_ ``/``; the corresponding assignments ``+=``, ``-=``, ``*=``, and ``/=``; as well as
 increment ``++`` and decrement ``--``.
 
 .. code-block:: c

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -126,7 +126,7 @@ whatever gap is present.
 
 The concepts of ``box`` and ``stretch`` are inspired by the concept of “boxes and glues" in
 the TeX language :cite:`knuth1984texbook`. This similarity
-is natural; TeXaims to resolve the spacing between characters in order
+is natural; TeX aims to resolve the spacing between characters in order
 to typeset a page, and the size of characters depend on the backend
 font. In OpenQASM we intend to resolve the timing of different
 instructions in order to meet high-level design intents, while the true
@@ -146,13 +146,13 @@ including stretches, will be resolved to constants.
 
 .. code-block:: c
 
-       length a = 300ns
-       length b = lengthof({x %0})
+       length a = 300ns;
+       length b = lengthof({x %0});
        stretch c;
        // stretchy length with min=300ns
-       length d = a + 2 * c
+       length d = a + 2 * c;
        // stretchy length with backtracking by up to half b
-       length e = -0.5 * b + c
+       length e = -0.5 * b + c;
 
 Delays (and other lengthened instructions)
 ----------------------------------------
@@ -265,7 +265,7 @@ to properly take into account the finite length of each gate.
    x %0;
    delay[middle_stretch] %0;
    y %0;
-   delay[middle_stretch] %0;=
+   delay[middle_stretch] %0;
    x %0;
    delay[middle_stretch] %0;
    y %0;

--- a/source/language/insts.rst
+++ b/source/language/insts.rst
@@ -68,7 +68,7 @@ broadcasts to ``b[j] = measure a[j];`` for each index ``j`` into register ``a``.
    .. image:: ../qpics/c6.svg
 
    The ``measure`` statement projectively measures a qubit or each qubit of a quantum
-   register. The measurement projects onto the $Z$-basis and leaves qubits available for further
+   register. The measurement projects onto the :math:`Z`-basis and leaves qubits available for further
    operations. The top row of circuits depicts single-qubit measurement using the statement
    ``c[0] = measure q[0];`` while the bottom depicts measurement of an entire register using the
    statement ``c = measure q;``. The center circuit of the top row depicts measurement as the


### PR DESCRIPTION
I also pinned the version of sphinxcontrib-bibtex since they just released a new version which broke the build.