### PR TITLE
fix wrong notations in examples/

### DIFF
--- a/examples/dd.qasm
+++ b/examples/dd.qasm
@@ -5,9 +5,9 @@
 OPENQASM 3.0;
 include "stdgates.inc";
 
-length start_stretch = -0.5 * lengthof({x %0;}) + stretch
-length middle_stretch = -0.5 * lengthof({x %0;}) - 5 * lengthof({y %0;} + stretch
-length end_stretch = -0.5 * lengthof({y %0;}) + stretch
+length start_stretch = -0.5 * lengthof({x %0;}) + stretch;
+length middle_stretch = -0.5 * lengthof({x %0;}) - 5 * lengthof({y %0;}) + stretch;
+length end_stretch = -0.5 * lengthof({y %0;}) + stretch;
 
 box {
   delay[start_stretch] %0;

--- a/examples/inverseqft1.qasm
+++ b/examples/inverseqft1.qasm
@@ -6,7 +6,7 @@ qubit q[4];
 bit c[4];
 reset q;
 h q;
-barrier q
+barrier q;
 h q[0];
 c[0] = measure q[0];
 if(int(c) == 1) { rz(pi / 2) q[1]; }

--- a/examples/varteleport.qasm
+++ b/examples/varteleport.qasm
@@ -27,7 +27,7 @@ rz(pi / 4) input;
 
 let io = input;
 for i in [0: n_pairs - 1] {
-  let bp = q[2 * i, 2 * i + 1];
+  let bp = q[2 * i: 2 * i + 1];
   bit pf[2];
   bellprep bp;
   cx io, bp[0];

--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -16,7 +16,7 @@ const shots = 1000;   // number of shots per Pauli observable
 // Parameters could be written to local variables for this
 // iteration, but we will request them using kernel functions
 kernel get_parameter uint[prec], uint[prec] -> angle[prec];
-kernel get_npaulis -> uint[prec]:
+kernel get_npaulis -> uint[prec];
 kernel get_pauli int[prec] -> bit[2 * n];
 
 // The energy calculation uses fixed point division,
@@ -59,7 +59,7 @@ def trial_circuit qubit[n]:q {
 /* Apply VQE ansatz circuit and measure a Pauli operator
  * given by spec. Return the number of 1 outcomes.
  */
-def counts_for_term(bit[2*n]:spec) qubit[n] -> uint[prec] {
+def counts_for_term(bit[2*n]:spec) qubit[n]:q -> uint[prec] {
   uint[prec] counts;
   for i in [1: shots] {
     bit b;


### PR DESCRIPTION
This PR fixes several wrong statements in `examples`.

Comment: I'm not sure whether `stretch` can be in an expression because it is a type.