### PR TITLE
Pulse-level control instructions

### DIFF
--- a/source/bibliography.bib
+++ b/source/bibliography.bib
@@ -266,7 +266,7 @@
     number = {2},
     pages = {113--130},
     year = {2005}
-    
+
 }
 
 @article{chiselq,
@@ -386,7 +386,7 @@
 }
 
 @misc{khammassi18,
-      title={cQASM v1.0: Towards a Common Quantum Assembly Language}, 
+      title={cQASM v1.0: Towards a Common Quantum Assembly Language},
       author={N. Khammassi and G. G. Guerreschi and I. Ashraf and J. W. Hogaboam and C. G. Almudever and K. Bertels},
       year={2018},
       eprint={1805.09607},
@@ -399,4 +399,22 @@
   author={Desef, Benjamin},
   journal={arXiv preprint arXiv:2007.12931},
   year={2020}
+}
+
+@article{levine2019,
+    author = {H.~Levine and A.~Keesling and G.~Semeghini and A.~Omran and T.T.~Wang and S.~Ebadi and H.~Bernien and M.~Greiner and V.~Vuleti{\'{c}} and H.~Pichler and M.D.~Lukin},
+    title = {Parallel Implementation of High-Fidelity Multiqubit Gates with Neutral Atoms},
+    journal = {Phys. Rev. Lett.},
+    volume = {123},
+    number = {17},
+    year = {2019}
+}
+
+@article{mckay2018,
+    author = {D.C.~Mckay and and T.~Alexander and L.~Bello and M.J.~Biercuk and L.~Bishop and J.~Chen and J.M.~Chow and D.C.~Antonio and D.~Egger and S.~Filipp and J.~Gomez and M.~Hush and A.~Javadi-Abhari and D.~Moreda and P.~Nation and B.~Paulovicks and E.~Winston and C.J.~Wood and J.~Wootton and J.M.~Gambetta},
+    title = {Qiskit Backend Specifications for OpenQASM and OpenPulse Experiments},
+    year = {2018}
+    eprint = {1809.03452v1},
+    archivePrefix = {arXiv},
+    primaryClass={quant-ph}
 }

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -292,7 +292,7 @@ We introduce a ``boxas`` expression for labeling a box. We primarily use this to
 later refer to the length of this box. Boxed expressions are good for
 this because their contents are isolated and cannot be combined with
 gates outside the box. Therefore, no matter how the contents of the box
-get optimized, the ``lengthof(boxlabel`` has a well-defined meaning.
+get optimized, the ``lengthof(boxlabel)`` has a well-defined meaning.
 
 .. code-block:: c
 

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -155,7 +155,7 @@ including stretches, will be resolved to constants.
        length e = -0.5 * b + c;
 
 Delays (and other lengthened instructions)
-----------------------------------------
+------------------------------------------
 
 OpenQASM and OpenPulse have a ``delay`` instruction, whose duration is defined by
 a ``length``. If the length passed to the delay contains stretch, it will become a

--- a/source/language/index.rst
+++ b/source/language/index.rst
@@ -22,3 +22,4 @@ Appendix `[app:semantics] <#app:semantics>`__ gives formal semantics.
    directives
    delays
    pulses
+   openpulse

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -126,7 +126,7 @@ The relevant instructions are:
 - ``set_phase`` and ``shift_phase``
 - ``set_scale`` and ``shift_scale``
 
-Here's an example of using ``shift_scale`` to calibrate an ``rz`` gate:
+Here's an example of using ``shift_phase`` to calibrate an ``rz`` gate:
 
 .. code-block:: none
 

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -1,0 +1,316 @@
+OpenPulse Grammar
+=================
+
+In addition to OpenQASM instructions, ``defcal`` blocks may contain OpenPulse 
+instructions. Or equivalently stated: OpenPulse instructions cannot appear
+outside of a ``defcal`` block.
+
+These instructions are motivated by the original OpenPulse specification which
+was defined as a JSON wire-format for pulse-level quantum programs in the paper
+`Qiskit Backend Specifications for OpenQASM and OpenPulse Experiment <https://arxiv.org/abs/1809.03452>`_. 
+The text format described here has several advantages over the equivalent JSON 
+format:
+
+- It is more readable
+- Absolute time is handled through built-in timekeeping instructions
+- Gates and classical instructions can be mixed in with the pulses to create far richer calibrations
+- Pulse definitions are tied to circuit instructions rather than circuit programs
+- Richer handling of frames
+
+Channels
+--------
+
+Channels map to a hardware resource, which can play pulses to manipulate a qubit
+or capture signal from the qubit to perform a measurement. There is a many-to-many
+relationship between qubits and channels. One qubit may have multiple channels
+connecting to it. Pulses on different channels would have different physical
+interactions with that qubit. A channel may also have many qubits. For instance,
+a channel could manipulate the coupling between two neighboring qubits, or
+could even reference multiple qubits in a chain.
+
+Channels are vendor-specific and device-specific. It is expected that vendors
+of quantum hardware provide the appropriate channel names and qubit mappings
+for use by end users. Each channel may also have associated static settings,
+such as local-oscillator frequencies, which do not vary throughout program
+execution. Again it is expected that vendors of quantum hardware provide a
+method for manipulating those static settings if appropriate.
+
+There are two kinds of channels: transmit channels (sending input to a quantum
+device) and receive channels (reading output from a quantum device).
+
+The ``channel`` type is a compile-time type representing a channel.
+
+A value of type ``channel`` is retreived with the special functions
+``transmit`` and ``receive``. These functions take an optional string argument
+followed by 1 or more physical qubits.
+
+The hardware vendor, during compilation, will substitute valid calls to
+``transmit`` and ``receive`` with their corresponding channels.
+
+A recommended convention: calling ``transmit`` with a single qubit argument
+should return the channel for driving single qubit gates, and calling
+``receive`` with a single qubit argument should return the channel for reading
+out the state of that qubit.
+
+.. code-block:: none
+
+   // Get the default input channel for qubit 0
+   transmit(%0)
+   // Get the default output channel for qubit 1
+   receive(%1)
+   // Get an input channel named "measure" for qubit 1
+   // Could be used to specify the measurement stimulus channel
+   transmit("measure", %1)
+   // Get an output channel named "cr1" for qubit 0
+   receive("cr1", %0)
+   // Get the default output channel for qubits 0 and 1
+   receive(%0, %1)
+
+Frames
+------
+
+It turns out to be quite useful to keep track of a set of carrier signals
+throughout the execution of a program. These carrier signals are called "frames"
+and are defined by :math:$A*e^{i\left(2\pi f t + \theta\right)}$, where `f` is
+frequency, `theta` is phase, and `A` is a scaling factor.
+
+Frames are attached to channels by a 1:1 correspondence. Every frame must 
+specify a frequency before any pulses can be played on that channel. The special 
+``prelude`` defcal is a good place to place these instructions.
+
+.. code-block:: none
+
+   defcal prelude {
+      // Required: set the frequency to 5GHz
+      initframe transmit(%1), 5e9;
+      // Optional: set the starting phase (otherwise it would start at 0)
+      set_phase transmit(%1), pi;
+   }
+
+Frames track the set of (frequency, phase, scale) throughout the program and 
+are manipulated using the following `set_` and `shift_` commands. Then when
+a pulse is played the carrier signal of the frame is mixed with the pulse itself
+to create the final signal which will be applied on the channel.
+
+Frequency has no default since it must be set at the beginning. Phase defaults
+to 0 and is a value of type ``angle``. Scale defaults to 1.0 and is a value of
+type ``float``. The exact precision of these three parameters is hardware
+specific.
+
+frameof command
+~~~~~~~~~~~~~~~
+
+The ``frame`` type is a compile-time type represnting a frame. It is useful
+when playing a pulse using the frame of a different channel.
+
+A value of type ``frame`` is retrieved by calling the ``frameof`` command
+and passing in a channel.
+
+Frame manipulation
+~~~~~~~~~~~~~~~~~~
+
+The (frequency, phase, scale) of a frame can be manipulated throughout program
+execution with the following instructions. After a call to one of these
+instructions, future references to that frame will have the new value.
+
+All of the following instructions have the same form. The first parameter can 
+either be a ``frame`` type or a ``channel`` type (in which case the 
+corresponding frame will be used). The second parameter is the value to shift
+or set. It must be the appropriate type, ``float`` for frequency, ``angle`` for
+phase, and ``float`` for scale. Again, the exact precision of these calculations
+is hardware specific.
+
+The relevant instructions are:
+
+- ``set_frequency`` and ``shift_frequency``
+- ``set_phase`` and ``shift_phase``
+- ``set_scale`` and ``shift_scale``
+
+Here's an example of using ``shift_scale`` to calibrate an ``rz`` gate:
+
+.. code-block:: none
+
+   // Shift phase of qubit 0's frame by pi/4, eg. an rz gate with angle -pi/4
+   shift_phase transmit(%0), pi/4;
+
+   // Equivalent, but more verbose
+   frame fr = frameof(transmit(%0));
+   shift_phase fr, pi/4;
+
+   // Define a calibration for the rz gate on all physical qubits
+   defcal rz(angle[20]:theta) %q {
+     shift_phase transmit(%q), -theta;
+   }
+
+Here's an example qubit spectroscopy experiment.
+
+.. code-block:: none
+
+   qubit q;
+
+   const shots = 1000;
+   const dfreq = 1e6; # 1MHz per point
+   const points = 50; # Sweep over 50MHz
+
+   complex[32] iq, average;
+   complex[32] output[points];
+
+   for p in [0 : points-1] {
+     average = 0;
+     for i in [0 : shots-1] {
+       // Assumes suitable calibrations for reset, x, and measure_iq
+       reset q;
+       x q;
+       measure_iq q -> iq;
+
+       average = (average * i + iq) / (i + 1);
+     }
+     shift q;
+     output[p] = average;
+   }
+
+   defcal prelude {
+      set_frequency transmit(%q) 5e9;
+   }
+
+   defcal shift %q {
+     shift_frequency transmit(%q) dfreq;
+   }
+
+Pulses
+------
+
+Pulses have two representations:
+
+- An array of complex samples which define the points for the pulse envelope
+- A``pulse`` type, which describes an abstract mathematical function
+  representing a pulse. This will later be materialized into a list of complex
+  samples, either by the compiler or the hardware using the parameters provided
+  to the pulse template.
+
+A value of type ``pulse`` is retrieved by calling one of the built-in pulse
+template functions. Note that each of these functions takes a type ``length``
+as a first argument, since pulses need to have a definite length. Using the
+hardware dependent ``dt`` unit is recommended, since the compiler may need to
+down-sample a higher precision pulse to physically realize it.
+
+.. code-block:: none
+
+   // amp is pulse amplitude at center
+   // center is the mean of pulse
+   // sigma is the standard deviation of pulse
+   gaussian(length:l, complex[float[32]]:amp, length:center, length:sigma)
+
+   // amp is pulse amplitude at center
+   // center is the mean of pulse
+   // sigma is the standard deviation of pulse
+   sech(length:l, complex[float[32]]:amp, length:center, length:sigma)
+
+   // amp is pulse amplitude at center
+   // center is the mean of pulse
+   // square_width is the width of the square pulse component
+   // sigma is the standard deviation of pulse
+   gaussian_square(length:l, complex[float[32]]:amp, length:center, length:square_width, length:sigma)
+
+   // amp is pulse amplitude at center
+   // center is the mean of pulse
+   // sigma is the standard deviation of pulse
+   // beta is the Y correction amplitude, see the DRAG paper
+   drag(length:l, complex[float[32]]:amp, length:center, length:sigma, float[32]:beta)
+
+   // Define a boxcar (aka. constant) pulse of length l
+   boxcar(l:length)
+
+Play instruction
+~~~~~~~~~~~~~~~~
+
+Pulses are scheduled using the ``play`` instruction. Play instructions have two
+required parameters:
+
+- the channel on which to play the pulse
+- a value of type ``pulse`` representing the pulse envelope
+
+Optionally the ``play`` instruction can also take a third parameter: the frame
+to use for the pulse. If the frame is not specified then the corresponding frame
+for the channel will be used instead, as if ``frameof`` was called for that
+channel.
+
+.. code-block:: none
+
+   // Play a 3 sample pulse on qubit 0
+   play transmit(%0), [1+0*j, 0+1*j, 1/sqrt(2)+1/sqrt(2)*j];
+
+   // Play a gaussian on qubit 0 using qubit 1's frame
+   frame f1 = frameof(transmit(%1));
+   play transmit(%0), gaussian(...), f1;
+
+Capture Instruction
+-------------------
+
+Acquisition is scheduled by a ``capture`` instruction. This is a special
+``kernel`` function which is specified by a hardware vendor. The measurement
+process is difficult to describe generically due to the wide variety of
+hardware and measurement methods.
+
+The only required parameter is an ``channel``, ie. a channel returned from
+calling the ``receive`` function.
+
+The following are possible parameters that might be included:
+
+- A "duration" of type ``length``, if it cannot be inferred from other parameters
+- A "filter", which is dot product-ed with the measured IQ the distill the
+  result into a single IQ value
+- A "tag", which could be used to identify which branch of an if statement was
+  traversed
+
+Again it is up to the hardware vendor to determine the parameters and write a
+kernel definition at the top-level, such as:
+
+.. code-block:: none
+
+   // Minimum requirement
+   kernel capture(channel output) -> complex[32];
+
+   // A capture command with more features
+   kernel capture(channel output, pulse filter) -> complex[32];
+
+The return type of a ``capture`` command varies. It could be a raw trace, ie a
+list of samples taken over a short period of time. It could be some averaged IQ
+value. It could be a classified bit. Or it could even have no return value,
+pushing the results into some buffer which is then accessed outside the program.
+
+Timing
+------
+
+Each channel maintains its own "clock". When a pulse is played the clock for 
+that channel advances by the length of the pulse. The same is true
+for output channels. Pulses on a single channel cannot be played simultaneously,
+although pulses on multiple channels for the same qubit can.
+
+For channels, everything behaves analogous to qubits in the 
+`Delays <delays.html>`_ section of this specification. There are however some
+small differences.
+
+The ``delay`` instruction may take a channel instead of a qubit. If a ``delay``
+instruction is applied to the qubit, this is the same as applying the delay to
+all channels on the qubit simultaneously.
+
+The ``barrier`` instruction on a qubit implies a barrier on all channels defined
+for that qubit. A barrier instruction will advance the clocks on all channels of
+the qubit to the channel with the highest clock.
+
+``defcal`` blocks have an implicit barrier on every qubit argument, meaning
+that clocks are guaranteed to be aligned at the start of the ``defcal`` block.
+These blocks also need to have a well-defined length, similar to the ``boxas``
+block.
+
+.. code-block:: none
+
+   pulse p = ...;
+
+   defcal simultaneous_pulsed_gate %0 {
+     play transmit("channel1", %0), p;
+     delay[20dt] transmit("channel2", %0);
+     // Starts the 100dt pulse 20dt into "channel1" already playing it
+     play transmit("channel1", %0), pulse;
+   }

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -82,7 +82,7 @@ specify a frequency before any pulses can be played on that channel. The special
 
    defcal prelude {
       // Required: set the frequency to 5GHz
-      initframe transmit(%1), 5e9;
+      set_frequency transmit(%1), 5e9;
       // Optional: set the starting phase (otherwise it would start at 0)
       set_phase transmit(%1), pi;
    }

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -165,7 +165,7 @@ Here's an example qubit spectroscopy experiment.
 
    for p in [0 : points-1] {
      // The key line: pick the frequency to sample
-     driveframe.frequency = start + (end-start) / points;
+     driveframe.frequency = start + (end-start) * p / points;
      output[p] = 0;
 
      for i in [0 : shots-1] {

--- a/source/language/openpulse.rst
+++ b/source/language/openpulse.rst
@@ -2,8 +2,8 @@ OpenPulse Grammar
 =================
 
 In addition to OpenQASM instructions, ``defcal`` blocks may contain OpenPulse 
-instructions. Or equivalently stated: OpenPulse instructions cannot appear
-outside of a ``defcal`` block.
+instructions. Certain OpenPulse instructions are further restricted to only
+appearing inside of a ``defcal`` block.
 
 These instructions are motivated by the original OpenPulse specification which
 was defined as a JSON wire-format for pulse-level quantum programs in the paper
@@ -30,41 +30,18 @@ could even reference multiple qubits in a chain.
 
 Channels are vendor-specific and device-specific. It is expected that vendors
 of quantum hardware provide the appropriate channel names and qubit mappings
-for use by end users. Each channel may also have associated static settings,
-such as local-oscillator frequencies, which do not vary throughout program
-execution. Again it is expected that vendors of quantum hardware provide a
-method for manipulating those static settings if appropriate.
+as configuration information to end users. Each channel may also have associated 
+static settings, such as local-oscillator frequencies, which do not vary 
+throughout program execution. Again it is expected that vendors of quantum 
+hardware provide a method for manipulating those static settings if appropriate.
 
 There are two kinds of channels: transmit channels (sending input to a quantum
 device) and receive channels (reading output from a quantum device).
 
-The ``channel`` type is a compile-time type representing a channel.
-
-A value of type ``channel`` is retreived with the special functions
-``transmit`` and ``receive``. These functions take an optional string argument
-followed by 1 or more physical qubits.
-
-The hardware vendor, during compilation, will substitute valid calls to
-``transmit`` and ``receive`` with their corresponding channels.
-
-A recommended convention: calling ``transmit`` with a single qubit argument
-should return the channel for driving single qubit gates, and calling
-``receive`` with a single qubit argument should return the channel for reading
-out the state of that qubit.
-
-.. code-block:: none
-
-   // Get the default input channel for qubit 0
-   transmit(%0)
-   // Get the default output channel for qubit 1
-   receive(%1)
-   // Get an input channel named "measure" for qubit 1
-   // Could be used to specify the measurement stimulus channel
-   transmit("measure", %1)
-   // Get an output channel named "cr1" for qubit 0
-   receive("cr1", %0)
-   // Get the default output channel for qubits 0 and 1
-   receive(%0, %1)
+Interacting with channels directly is onerous and makes the pulse programs less
+portable. The OpenPulse defcalgrammar does not directly work with channels and
+instead works with abstract "frames", described below. The static settings above 
+should also include a mapping of these abstract frames to the correct channels.
 
 Frames
 ------
@@ -72,74 +49,102 @@ Frames
 It turns out to be quite useful to keep track of a set of carrier signals
 throughout the execution of a program. These carrier signals are called "frames"
 and are defined by :math:$A*e^{i\left(2\pi f t + \theta\right)}$, where `f` is
-frequency, `theta` is phase, and `A` is a scaling factor.
+frequency, `theta` is phase, and `A` is a scaling factor. Frames will also track
+time appropriately so programs do not need to deal in absolute time. The
+canonical motivation for keeping track of phase is to implement a "virtual
+Z-gate", which does not require a physical pulse but rather shifts the phase of
+all future pulses on that frame.
 
-Frames are attached to channels by a 1:1 correspondence. Every frame must 
-specify a frequency before any pulses can be played on that channel. The special 
-``prelude`` defcal is a good place to place these instructions.
+The ``frame`` type is a compile-type type representing a *reference* to a frame.
+The frame is composed of four parts:
 
-.. code-block:: none
+1. A frequency ``frequency`` of type ``float``. It is not initialized and must
+be set before any pulses can be played on that frame.
+2. A phase ``phase`` of type ``angle``. This is initialized to the value 0.
+3. An amplitude ``scale`` of type ``float``. This is initilized to the value 1.0.
+4. A time of type ``dt`` which is manipulated implicitly and cannot be modified
+other than through existing timing instructions like ``delay`` and ``barrier``.
 
-   defcal prelude {
-      // Required: set the frequency to 5GHz
-      set_frequency transmit(%1), 5e9;
-      // Optional: set the starting phase (otherwise it would start at 0)
-      set_phase transmit(%1), pi;
-   }
-
-Frames track the set of (frequency, phase, scale) throughout the program and 
-are manipulated using the following `set_` and `shift_` commands. Then when
-a pulse is played the carrier signal of the frame is mixed with the pulse itself
-to create the final signal which will be applied on the channel.
-
-Frequency has no default since it must be set at the beginning. Phase defaults
-to 0 and is a value of type ``angle``. Scale defaults to 1.0 and is a value of
-type ``float``. The exact precision of these three parameters is hardware
-specific.
+The exact precision of these parameters is hardware specific.
 
 frameof command
 ~~~~~~~~~~~~~~~
 
-The ``frame`` type is a compile-time type represnting a frame. It is useful
-when playing a pulse using the frame of a different channel.
+Frames are uniquely identified by a string name and a set of qubits. The order
+of qubits does not matter.
 
-A value of type ``frame`` is retrieved by calling the ``frameof`` command
-and passing in a channel.
+Frames are retrieved using the ``frameof`` function and passing in the name and
+list of physical qubits.
+
+.. code-block: none
+
+   frameof("drive", %0)
+   
+   // These next two lines refer to the same frame
+   frameof("coupling", %0, %1)
+   frameof("coupling", %1, %0)
+
+Frame names may seem like they ascribe meaning or that there are only certain
+permissable names. This is not the case; frame names are arbitrary. The frames
+are later mapped to channel names that do have meaning for a certain hardware
+vendor. For example, the hardware vendor may choose to map frames to channels
+using JSON:
+
+.. code-block: javascript
+
+   {
+     drive: {
+       "{0}": "channel0",
+       "{1}": "channel1"
+     coupling: {
+       "{0,1}": "channel2"
+     }
+   }
+
+This has the advantage that one can run any program with any arbitrary frame
+names provided a mapping to the appropriate channels is given.
+
+Restrictions on the use of frames
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+
+There are two important considersations when dealing with frames.
+
+First, frames are compile time constants. Runtime variables cannot be used as
+arguments to frames; the frame must be resolvable at compile time. This also
+means that assigning a frame to an alias (for the purpose of avoiding typing)
+needs to be done with ``const`` not ``let``.
+
+.. code-block: none
+
+   const driveframe = frameof("drive", %0);
+
+Second, frames return references not values. This means that calling the same
+``frameof`` command in different places is the same as assigning the frame to a
+constant and referencing it multiple times.
 
 Frame manipulation
 ~~~~~~~~~~~~~~~~~~
 
 The (frequency, phase, scale) of a frame can be manipulated throughout program
-execution with the following instructions. After a call to one of these
-instructions, future references to that frame will have the new value.
-
-All of the following instructions have the same form. The first parameter can 
-either be a ``frame`` type or a ``channel`` type (in which case the 
-corresponding frame will be used). The second parameter is the value to shift
-or set. It must be the appropriate type, ``float`` for frequency, ``angle`` for
+by referencing ``.frequency``, ``.phase``, and ``.scale``. Operations must be 
+appropriate for the respective type, ``float`` for frequency, ``angle`` for
 phase, and ``float`` for scale. Again, the exact precision of these calculations
 is hardware specific.
 
-The relevant instructions are:
-
-- ``set_frequency`` and ``shift_frequency``
-- ``set_phase`` and ``shift_phase``
-- ``set_scale`` and ``shift_scale``
-
-Here's an example of using ``shift_phase`` to calibrate an ``rz`` gate:
+Here's an example of manipulating the phase to calibrate an ``rz`` gate:
 
 .. code-block:: none
 
-   // Shift phase of qubit 0's frame by pi/4, eg. an rz gate with angle -pi/4
-   shift_phase transmit(%0), pi/4;
+   // Shift phase of qubit 0's "drive" frame by pi/4, eg. an rz gate with angle -pi/4
+   frameof("drive", %0).phase += pi/4;
 
-   // Equivalent, but more verbose
-   frame fr = frameof(transmit(%0));
-   shift_phase fr, pi/4;
+   // Equivalent
+   const drive = frameof("drive", %0);
+   drive.phase += pi/4;
 
    // Define a calibration for the rz gate on all physical qubits
    defcal rz(angle[20]:theta) %q {
-     shift_phase transmit(%q), -theta;
+     frameof("drive", %q).phase -= theta;
    }
 
 Here's an example qubit spectroscopy experiment.
@@ -149,33 +154,39 @@ Here's an example qubit spectroscopy experiment.
    qubit q;
 
    const shots = 1000;
-   const dfreq = 1e6; # 1MHz per point
-   const points = 50; # Sweep over 50MHz
+   const start = 5e9; // 5 GHz
+   const end = 6e9; // 6 GHz
+   const points = 50;
 
    complex[32] iq, average;
    complex[32] output[points];
 
+   const driveframe = frameof("drive", q);
+
    for p in [0 : points-1] {
-     average = 0;
+     // The key line: pick the frequency to sample
+     driveframe.frequency = start + (end-start) / points;
+     output[p] = 0;
+
      for i in [0 : shots-1] {
        // Assumes suitable calibrations for reset, x, and measure_iq
+       // and that the x gate references the same "drive" frame
        reset q;
        x q;
        measure_iq q -> iq;
 
-       average = (average * i + iq) / (i + 1);
+       output[p] = (output[p] * i + iq) / (i + 1);
      }
-     shift q;
-     output[p] = average;
    }
 
-   defcal prelude {
-      set_frequency transmit(%q) 5e9;
-   }
+Manipulating frames based on the state of other frames is also permitted:
 
-   defcal shift %q {
-     shift_frequency transmit(%q) dfreq;
-   }
+.. code-block:: none
+
+   // Swap phases between two frames
+   const temp = frame1.phase;
+   frame1.phase = frame2.phase;
+   frame2.phase = temp;
 
 Pulses
 ------
@@ -218,31 +229,28 @@ down-sample a higher precision pulse to physically realize it.
    // beta is the Y correction amplitude, see the DRAG paper
    drag(length:l, complex[float[32]]:amp, length:center, length:sigma, float[32]:beta)
 
-   // Define a boxcar (aka. constant) pulse of length l
-   boxcar(l:length)
+   // Define a constant pulse of length l
+   constant(l:length)
 
 Play instruction
-~~~~~~~~~~~~~~~~
+----------------
 
-Pulses are scheduled using the ``play`` instruction. Play instructions have two
-required parameters:
+Pulses are scheduled using the ``play`` instruction. These instructions may
+only appear inside a ``defcal`` block!
 
-- the channel on which to play the pulse
+Play instructions have two required parameters:
+
 - a value of type ``pulse`` representing the pulse envelope
-
-Optionally the ``play`` instruction can also take a third parameter: the frame
-to use for the pulse. If the frame is not specified then the corresponding frame
-for the channel will be used instead, as if ``frameof`` was called for that
-channel.
+- the frame to use for the pulse
 
 .. code-block:: none
 
-   // Play a 3 sample pulse on qubit 0
-   play transmit(%0), [1+0*j, 0+1*j, 1/sqrt(2)+1/sqrt(2)*j];
+   // Play a 3 sample pulse on qubit 0's "drive" frame
+   play([1+0*j, 0+1*j, 1/sqrt(2)+1/sqrt(2)*j]) frameof("drive", %0);
 
-   // Play a gaussian on qubit 0 using qubit 1's frame
-   frame f1 = frameof(transmit(%1));
-   play transmit(%0), gaussian(...), f1;
+   // Play a gaussian on qubit 1's "drive" frame
+   frame f1 = frameof("drive", %1);
+   play(gaussian(...)) f1;
 
 Capture Instruction
 -------------------
@@ -250,10 +258,10 @@ Capture Instruction
 Acquisition is scheduled by a ``capture`` instruction. This is a special
 ``kernel`` function which is specified by a hardware vendor. The measurement
 process is difficult to describe generically due to the wide variety of
-hardware and measurement methods.
+hardware and measurement methods. Like the play instruction, these instructions
+may only appear inside a ``defcal`` block!
 
-The only required parameter is an ``channel``, ie. a channel returned from
-calling the ``receive`` function.
+The only required parameter is a ``frame``.
 
 The following are possible parameters that might be included:
 
@@ -269,12 +277,12 @@ kernel definition at the top-level, such as:
 .. code-block:: none
 
    // Minimum requirement
-   kernel capture(channel output) -> complex[32];
+   kernel capture(frame output) -> complex[32];
 
    // A capture command with more features
-   kernel capture(channel output, pulse filter) -> complex[32];
+   kernel capture(frame output, pulse filter) -> complex[32];
 
-The return type of a ``capture`` command varies. It could be a raw trace, ie a
+The return type of a ``capture`` command varies. It could be a raw trace, ie. a
 list of samples taken over a short period of time. It could be some averaged IQ
 value. It could be a classified bit. Or it could even have no return value,
 pushing the results into some buffer which is then accessed outside the program.
@@ -282,35 +290,28 @@ pushing the results into some buffer which is then accessed outside the program.
 Timing
 ------
 
-Each channel maintains its own "clock". When a pulse is played the clock for 
-that channel advances by the length of the pulse. The same is true
-for output channels. Pulses on a single channel cannot be played simultaneously,
-although pulses on multiple channels for the same qubit can.
+Each frame maintains its own "clock". When a pulse is played the clock for 
+that frame advances by the length of the pulse. 
 
-For channels, everything behaves analogous to qubits in the 
+For frames, everything behaves analogous to qubits in the 
 `Delays <delays.html>`_ section of this specification. There are however some
 small differences.
 
-The ``delay`` instruction may take a channel instead of a qubit. If a ``delay``
-instruction is applied to the qubit, this is the same as applying the delay to
-all channels on the qubit simultaneously.
+The ``delay`` instruction may take a frame instead of a qubit. The ``barrier`` 
+instruction may also take a list of frames intead of a list of qubits.
 
-The ``barrier`` instruction on a qubit implies a barrier on all channels defined
-for that qubit. A barrier instruction will advance the clocks on all channels of
-the qubit to the channel with the highest clock.
-
-``defcal`` blocks have an implicit barrier on every qubit argument, meaning
-that clocks are guaranteed to be aligned at the start of the ``defcal`` block.
+``defcal`` blocks have an implicit barrier on every frame used within the block,
+meaning that clocks are guaranteed to be aligned at the start of the block.
 These blocks also need to have a well-defined length, similar to the ``boxas``
 block.
 
 .. code-block:: none
 
-   pulse p = ...;
+   pulse p = ...; // some 100dt pulse
 
    defcal simultaneous_pulsed_gate %0 {
-     play transmit("channel1", %0), p;
-     delay[20dt] transmit("channel2", %0);
-     // Starts the 100dt pulse 20dt into "channel1" already playing it
-     play transmit("channel1", %0), pulse;
+     play(p) frameof("drive0", %0);
+     delay[20dt] frameof("drive1", %0);
+     // Starts the 100dt pulse 20dt into "drive0" already playing it
+     play(p) frameof("drive1");
    }

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -73,11 +73,11 @@ the most specific definition found for a given operation. Thus, given,
 the operation ``rx(pi/2) %0`` would match to (3), ``rx(pi) %0`` would
 match (2), ``rx(pi/2) %1`` would match (1).
 
-Users specify the grammar used inside ``defcal`` blocks with a 
-``defcalgrammar "name"`` declaration. One such grammar is a 
+Users specify the grammar used inside ``defcal`` blocks with a
+``defcalgrammar "name"`` declaration. One such grammar is a
 `textual representation of OpenPulse <openpulse.html>`_ specified by:
 
-.. code-block: none
+.. code-block:: c
 
    defcalgrammar "openpulse" 1;
 
@@ -98,20 +98,18 @@ of prior versions of OpenQASM.
 Restrictions on defcal bodies
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-The contents of ``defcal`` bodies are subject to some restrictions. This is
-similar to how boxed expressions work.
+The contents of ``defcal`` bodies are subject to the restriction they must have a definite length
+known at compile time, regardless of the parameters passed in or the state of the system when
+called. This allows the compiler to properly resolve ``lengthof(...)`` calls and
+allows for optimizations. If there is to be control flow in the ``defcal``, each branch of the
+control flow must have definite and equivalent length resolvable at compile time. Similarly, loops
+must be have a resolvable definite length at compile time.
 
-- They must have a definite length, regardless of the parameters passed in or
-  the state of the system when called. This allows the compiler to properly
-  resolve ``lengthof(...)`` calls and allowing for optimizations.
-- No control flow is allowed within a ``defcal`` block (with one exception,
-  see below). This follows from the definite length requirement.
-
-The sole exception to the second rule is a ``reset`` gate. The ``defcal`` for a
-``reset`` gate is permitted to have a single if statement, provided each branch
+For example,  consider the case of a ``reset`` gate. The ``defcal`` for a
+``reset`` gate can be composed of a single if statement, provided each branch
 of the if statement has definite and equivalent length.
 
-.. code-block:: none
+.. code-block:: c
 
    defcal reset %0 {
       bit res = // measure qubit %0

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -16,7 +16,7 @@ instructions to the underlying microcoded
 :cite:`wilkesBestWayDesign1989` stimulus programs emitted by
 the controllers to implement each operation. In OpenQASM we expose
 access to this level of control with pulse-level definitions of gates
-and measurement using a `text representation of OpenPulse <openpulse.html>`_ 
+and measurement using a `textual representation of OpenPulse <openpulse.html>`_ 
 
 The entry point to such gate and measurement definitions is the ``defcal`` keyword
 analogous to the ``gate`` keyword, but where the ``defcal`` body specifies a pulse-level

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -16,7 +16,7 @@ instructions to the underlying microcoded
 :cite:`wilkesBestWayDesign1989` stimulus programs emitted by
 the controllers to implement each operation. In OpenQASM we expose
 access to this level of control with pulse-level definitions of gates
-and measurement using a `textual representation of OpenPulse <openpulse.html>`_ 
+and measurement with a user-selectable pulse grammar.
 
 The entry point to such gate and measurement definitions is the ``defcal`` keyword
 analogous to the ``gate`` keyword, but where the ``defcal`` body specifies a pulse-level
@@ -73,6 +73,17 @@ the most specific definition found for a given operation. Thus, given,
 the operation ``rx(pi/2) %0`` would match to (3), ``rx(pi) %0`` would
 match (2), ``rx(pi/2) %1`` would match (1).
 
+Users specify the grammar used inside ``defcal`` blocks with a 
+``defcalgrammar "name"`` declaration. One such grammar is a 
+`textual representation of OpenPulse <openpulse.html>`_ specified by:
+
+.. code-block: none
+
+   defcalgrammar "openpulse" 1;
+
+where ``1`` is the version number of the grammar. The ``defcalgrammar`` line
+must appear prior to any ``defcal`` definition.
+
 Note that ``defcal`` and ``gate`` communicate orthogonal information to the compiler. ``gate``'s
 define unitary transformation rules to the compiler. The compiler may
 freely invoke such rules on operations while preserving the structure of
@@ -110,36 +121,3 @@ of the if statement has definite and equivalent length.
          // delay for an equivalent amount of time
       }
    }
-
-Special defcals
-~~~~~~~~~~~~~~~
-
-There are two special ``defcal`` keys which are handled in a unique way:
-``prelude`` and ``postlude``. ``prelude`` inserts instructions at the
-beginning of the program, and the ``postlude`` inserts instructions at the
-end of the program. Unlike other ``defcal`` definitions, these do not take
-qubit parameters.
-
-These special defcals are especially useful for running any necessary
-instructions to initialize the program or collect results.
-
-.. code-block:: none
-
-   defcal prelude { ... }
-   defcal postlude { ... }
-
-A program such as this:
-
-.. code-block:: none
-
-   qubit a;
-   x a;
-
-would be transformed to insert the bodies of the two special defcals:
-
-.. code-block:: none
-
-   prelude;
-   qubit a;
-   x a;
-   postlude;


### PR DESCRIPTION
Proposal to add pulse-level control instructions to OpenQASM, in the form of an OpenPulse defcalgrammar. This represents several weeks of weeks of work from the OpenPulse working group.

Co-authored with @psivaraj

Tracking issue: #110 