### PR TITLE
Clarify assignment for subroutines

### DIFF
--- a/examples/gateteleport.qasm
+++ b/examples/gateteleport.qasm
@@ -25,7 +25,7 @@ rz(pi/4) a;
 cx q, a;
 
 // measure out the ancilla
-r = logical_meas;
+r = logical_meas a;
 
 // if we get a logical |1> then we need to apply a logical Z correction
 if (r == 1) z q;

--- a/examples/gateteleport.qasm
+++ b/examples/gateteleport.qasm
@@ -4,13 +4,13 @@ include "stdgates.inc";
 
 // declarations
 const n = 3;
-kernel vote bit[n] -> bit;
+kernel vote(bit[n]) -> bit;
 
 def logical_meas qubit[3]:d -> bit {
     bit c[3];
     bit r;
     measure d -> c;
-    vote c -> r;
+    r = vote(c);
     return r;
 }
 
@@ -25,7 +25,7 @@ rz(pi/4) a;
 cx q, a;
 
 // measure out the ancilla
-logical_meas a -> r;
+r = logical_meas;
 
 // if we get a logical |1> then we need to apply a logical Z correction
 if (r == 1) z q;

--- a/examples/qec.qasm
+++ b/examples/qec.qasm
@@ -7,11 +7,11 @@ qubit a[2];
 bit c[3];
 bit syn[2];
 
-def syndrome qubit[3]:d, qubit[2]:a -> bit[2] { 
+def syndrome qubit[3]:d, qubit[2]:a -> bit[2] {
   bit[2] b;
-  cx d[0], a[0]; 
-  cx d[1], a[0]; 
-  cx d[1], a[1]; 
+  cx d[0], a[0];
+  cx d[1], a[0];
+  cx d[1], a[1];
   cx d[2], a[1];
   measure a -> b;
   return b;
@@ -21,7 +21,7 @@ reset a;
 x q[0]; // insert an error
 barrier q;
 syn = syndrome q, a;
-// also valid: syndrome q, a -> syn;
+
 if(int(syn)==1) x q[0];
 if(int(syn)==2) x q[2];
 if(int(syn)==3) x q[1];

--- a/examples/scqec.qasm
+++ b/examples/scqec.qasm
@@ -14,9 +14,9 @@ const n = d^2;       // number of code qubits
 
 uint[32] failures;  // number of observed failures
 
-kernel zfirst creg[n - 1], int, int;
-kernel send creg[n -1 ], int, int, int;
-kernel zlast creg[n], int, int -> bit;
+kernel zfirst(creg[n - 1], int, int);
+kernel send(creg[n -1 ], int, int, int);
+kernel zlast(creg[n], int, int) -> bit;
 
 qubit data[n];  // code qubits
 qubit ancilla[n - 1];  // syndrome qubits
@@ -83,12 +83,12 @@ for shot in [1: shots] {
 
   // Initialize
   reset data;
-  cycle data, ancilla -> layer;
+  layer = cycle data, ancilla;
   zfirst(layer, shot, d);
 
   // m cycles of syndrome measurement
   for i in [1: m] {
-    cycle data, ancilla -> layer;
+    layer = cycle data, ancilla;
     send(layer, shot, i, d);
   }
 
@@ -102,4 +102,3 @@ for shot in [1: shots] {
 /* The ratio of "failures" to "shots" is our result.
  * The data can be logged by the external functions too.
  */
-

--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -15,14 +15,13 @@ const shots = 1000;   // number of shots per Pauli observable
 
 // Parameters could be written to local variables for this
 // iteration, but we will request them using kernel functions
-kernel get_parameter uint[prec], uint[prec] -> angle[prec];
+kernel get_parameter(uint[prec], uint[prec]) -> angle[prec];
 kernel get_npaulis -> uint[prec]:
-kernel get_pauli int[prec] -> bit[2 * n];
+kernel get_pauli(int[prec]) -> bit[2 * n];
 
 // The energy calculation uses fixed point division,
 // so we do that calculation in a kernel function
-kernel update_energy int[prec], uint[prec],
- fixed[prec,prec] -> fixed[prec,prec];
+kernel update_energy(int[prec], uint[prec], fixed[prec,prec]) -> fixed[prec,prec];
 
 gate entangler qubit[n]:q { for i in [0:n-2] { cx q[i], q[i+1]; } }
 def xmeasure qubit:q -> bit { h q; return measure q; }
@@ -36,9 +35,9 @@ def pauli_measurement(bit[2*n]:spec) qubit[n]:q -> bit {
   bit b = 0;
   for i in [0: n - 1] {
     bit temp;
-    if(spec[i]==1 && spec[n+i]==0) { xmeasure q[i] -> temp; }
-    if(spec[i]==0 && spec[n+i]==1) { measure q[i] -> temp; }
-    if(spec[i]==1 && spec[n+i]==1) { ymeasure q[i] -> temp; }
+    if(spec[i]==1 && spec[n+i]==0) { temp = xmeasure q[i]; }
+    if(spec[i]==0 && spec[n+i]==1) { temp = measure q[i]; }
+    if(spec[i]==1 && spec[n+i]==1) { temp = ymeasure q[i]; }
     b ^= temp;
   }
   return b;
@@ -49,7 +48,7 @@ def trial_circuit qubit[n]:q {
   for l in [0: layers - 1] {
     for i in [0: n - 1] {
       angle[prec] theta;
-      get_parameter(l * layers + i) -> theta;
+      theta = get_parameter(l * layers + i);
       ry(theta) q[i];
     }
     if(l != layers - 1) entangler q;

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -197,9 +197,10 @@ Kernel function calls
 ---------------------
 
 Kernel functions are declared by giving their signature using the
-statement ``kernel name(inputs)-> output;`` where inputs is a comma-separated list of type names and
-output is a single type name. They can be functions of any number of
-arguments whose types correspond to the classical types of OpenQASM.
+statement ``kernel name(inputs) -> output;`` where ``inputs`` is a comma-separated list of type names and
+``output`` is a single type name. The parentheses may be omitted if there are no ``inputs``.
+
+Kernel functions can take of any number of arguments whose types correspond to the classical types of OpenQASM.
 Inputs are passed by value. They can return zero or one value whose type
 is any classical type in OpenQASM except real constants. If necessary,
 multiple return values can be accommodated by concatenating registers.
@@ -207,13 +208,12 @@ The type and size of each argument must be known at compile time to
 define data flow and enable scheduling. We do not address issues such as
 how the kernel functions are defined and registered.
 
-Kernel functions are invoked using the statement ``name(inputs) -> output;``. The functions are not
+Kernel functions are invoked using the statement ``output = name(inputs);``, where ``inputs`` and
+``outputs`` are now literals corresponding to the types in the signature. The functions are not
 required to be idempotent. They may change the state of the process
 providing the function. In our computational model, the kernel functions
 are assumed to run concurrently with other classical and quantum
-computations. The output of a kernel function can be assigned to a
-variable on declaration using the assignment operator rather than the
-``->`` arrow notation.
+computations.
 
 .. [1]
    ``popcount`` computes the Hamming weight of the input register.

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -208,12 +208,11 @@ The type and size of each argument must be known at compile time to
 define data flow and enable scheduling. We do not address issues such as
 how the kernel functions are defined and registered.
 
-Kernel functions are invoked using the statement ``output = name(inputs);``, where ``inputs`` and
-``outputs`` are now literals corresponding to the types in the signature. The functions are not
-required to be idempotent. They may change the state of the process
-providing the function. In our computational model, the kernel functions
-are assumed to run concurrently with other classical and quantum
-computations.
+Kernel functions are invoked using the statement ``name(inputs);`` and the result may be assigned to
+``output`` as needed via an assignment operator (``=``, ``+=``, etc). ``inputs`` are literals and
+``output`` is a variable, corresponding to the types in the signature. The functions are not required to
+be idempotent. They may change the state of the process providing the function. In our computational
+model, the kernel functions are assumed to run concurrently with other classical and quantum computations.
 
 .. [1]
    ``popcount`` computes the Hamming weight of the input register.

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -4,11 +4,12 @@ Subroutines
 Subroutines are declared using the statement ``def name(parameters) qargs -> output { body }``.
 Zero or more quantum bits
 and registers are passed to the subroutine by reference or name in ``qargs``.
-Classical types are passed by value in ``parameters``. The subroutines return up to
+Classical types are passed by value in ``parameters``. The parentheses may be omitted if no
+``parameters`` are passed. The subroutines return up to
 one classical type. All arguments are declared together with their type,
 for example ``qubit: ancilla`` would define a quantum bit argument named ``ancilla``. The output of a
-subroutine can be assigned to a variable on declaration using the
-assignment operator or the ``->`` arrow notation.
+subroutine can be assigned to a variable on declaration using an
+assignment operator (``=``, ``+=``, etc).
 
 Using subroutines, we can define an X-basis measurement with the program
 ``def xmeasure qubit:q -> bit { h q; return measure q; }``.
@@ -51,7 +52,7 @@ follows
    c = measure q;
    c2 = measure r;
    bit result;
-   result = parity(c || c2); // or: parity(c || c2) -> result;
+   result = parity(c || c2);
 
 We require that we know the signature at compile time, as we do in this
 example. We could also just as easily have used a kernel function for
@@ -61,6 +62,6 @@ this
 
    const n = /* size of c + size of c2 */;
    kernel parity bit[n] -> bit;
-   measure q -> c;
-   measure r -> c2;
-   parity(c || c2) -> result; // or: result = parity(c || c2);
+   c = measure q;
+   c2 = measure r;
+   result = parity(c || c2);

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -7,9 +7,10 @@ and registers are passed to the subroutine by reference or name in ``qargs``.
 Classical types are passed by value in ``parameters``. The parentheses may be omitted if no
 ``parameters`` are passed. The subroutines return up to
 one classical type. All arguments are declared together with their type,
-for example ``qubit: ancilla`` would define a quantum bit argument named ``ancilla``. The output of a
-subroutine can be assigned to a variable on declaration using an
-assignment operator (``=``, ``+=``, etc).
+for example ``qubit: ancilla`` would define a quantum bit argument named ``ancilla``. A subroutine
+is invoked with the syntax ``name(parameters) qargs`` and may be assigned to an ``output`` as
+needed via an assignment operator (``=``, ``+=``, etc). ``parameters`` and ``qargs`` are literals
+and ``output`` is a variable.
 
 Using subroutines, we can define an X-basis measurement with the program
 ``def xmeasure qubit:q -> bit { h q; return measure q; }``.
@@ -61,7 +62,7 @@ this
 .. code-block:: c
 
    const n = /* size of c + size of c2 */;
-   kernel parity bit[n] -> bit;
+   kernel parity(bit[n]) -> bit;
    c = measure q;
    c2 = measure r;
    result = parity(c || c2);

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -50,6 +50,7 @@ follows
 
 .. code-block:: c
 
+   qubit q, r;
    c = measure q;
    c2 = measure r;
    bit result;
@@ -63,6 +64,8 @@ this
 
    const n = /* size of c + size of c2 */;
    kernel parity(bit[n]) -> bit;
+   qubit q, r;
    c = measure q;
    c2 = measure r;
+   bit result;
    result = parity(c || c2);

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -8,7 +8,7 @@ Classical types are passed by value in ``parameters``. The subroutines return up
 one classical type. All arguments are declared together with their type,
 for example ``qubit: ancilla`` would define a quantum bit argument named ``ancilla``. The output of a
 subroutine can be assigned to a variable on declaration using the
-assignment operator rather than the ``->`` arrow notation.
+assignment operator or the ``->`` arrow notation.
 
 Using subroutines, we can define an X-basis measurement with the program
 ``def xmeasure qubit:q -> bit { h q; return measure q; }``.
@@ -50,7 +50,8 @@ follows
 
    c = measure q;
    c2 = measure r;
-   result = parity(c || c2);
+   bit result;
+   result = parity(c || c2); // or: parity(c || c2) -> result
 
 We require that we know the signature at compile time, as we do in this
 example. We could also just as easily have used a kernel function for
@@ -62,4 +63,4 @@ this
    kernel parity bit[n] -> bit;
    measure q -> c;
    measure r -> c2
-   parity(c || c2) -> result;
+   parity(c || c2) -> result; // or: result = parity(c || c2)

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -51,7 +51,7 @@ follows
    c = measure q;
    c2 = measure r;
    bit result;
-   result = parity(c || c2); // or: parity(c || c2) -> result
+   result = parity(c || c2); // or: parity(c || c2) -> result;
 
 We require that we know the signature at compile time, as we do in this
 example. We could also just as easily have used a kernel function for
@@ -62,5 +62,5 @@ this
    const n = /* size of c + size of c2 */;
    kernel parity bit[n] -> bit;
    measure q -> c;
-   measure r -> c2
-   parity(c || c2) -> result; // or: result = parity(c || c2)
+   measure r -> c2;
+   parity(c || c2) -> result; // or: result = parity(c || c2);


### PR DESCRIPTION
Subroutine/kernel assignment should be done by `=` or another assignment operator `+=, *=`, etc and not by `->`. Parentheses should be required for classical arguments to kernels/subroutines and only be dropped if there are no such arguments.