### PR TITLE
Add sensible defaults for sizes in example variables

### DIFF
--- a/examples/inverseqft1.qasm
+++ b/examples/inverseqft1.qasm
@@ -9,20 +9,20 @@ h q;
 barrier q
 h q[0];
 c[0] = measure q[0];
-if(int(c) == 1) { rz(pi / 2) q[1]; }
+if(int[4](c) == 1) { rz(pi / 2) q[1]; }
 h q[1];
 c[1] = measure q[1];
-if(int(c) == 1){ rz(pi / 4) q[2]; }
-if(int(c) == 2){ rz(pi / 2) q[2]; }
-if(int(c) == 3){ rz(pi / 2 + pi / 4) q[2]; }
+if(int[4](c) == 1){ rz(pi / 4) q[2]; }
+if(int[4](c) == 2){ rz(pi / 2) q[2]; }
+if(int[4](c) == 3){ rz(pi / 2 + pi / 4) q[2]; }
 h q[2];
 c[2] = measure q[2];
-if(int(c) == 1) rz(pi / 8) q[3];
-if(int(c) == 2) rz(pi / 4) q[3];
-if(int(c) == 3) rz(pi/4+pi/8) q[3];
-if(int(c) == 4) rz(pi / 2) q[3];
-if(int(c) == 5) rz(pi / 2 + pi / 8) q[3];
-if(int(c) == 6) rz(pi / 2+ pi / 4) q[3];
-if(int(c) == 7) rz(pi / 2 + pi / 4 + pi / 8) q[3];
+if(int[4](c) == 1) rz(pi / 8) q[3];
+if(int[4](c) == 2) rz(pi / 4) q[3];
+if(int[4](c) == 3) rz(pi/4+pi/8) q[3];
+if(int[4](c) == 4) rz(pi / 2) q[3];
+if(int[4](c) == 5) rz(pi / 2 + pi / 8) q[3];
+if(int[4](c) == 6) rz(pi / 2+ pi / 4) q[3];
+if(int[4](c) == 7) rz(pi / 2 + pi / 4 + pi / 8) q[3];
 h q[3];
 c[3] = measure q[3];

--- a/examples/qec.qasm
+++ b/examples/qec.qasm
@@ -7,11 +7,11 @@ qubit a[2];
 bit c[3];
 bit syn[2];
 
-def syndrome qubit[3]:d, qubit[2]:a -> bit[2] { 
+def syndrome qubit[3]:d, qubit[2]:a -> bit[2] {
   bit[2] b;
-  cx d[0], a[0]; 
-  cx d[1], a[0]; 
-  cx d[1], a[1]; 
+  cx d[0], a[0];
+  cx d[1], a[0];
+  cx d[1], a[1];
   cx d[2], a[1];
   measure a -> b;
   return b;
@@ -22,7 +22,7 @@ x q[0]; // insert an error
 barrier q;
 syn = syndrome q, a;
 // also valid: syndrome q, a -> syn;
-if(int(syn)==1) x q[0];
-if(int(syn)==2) x q[2];
-if(int(syn)==3) x q[1];
+if(int[2](syn)==1) x q[0];
+if(int[2](syn)==2) x q[2];
+if(int[2](syn)==3) x q[1];
 c = measure q;

--- a/examples/rus.qasm
+++ b/examples/rus.qasm
@@ -32,7 +32,7 @@ reset input;
 h input;
 
 // braces are optional in this case
-while(int(flags) != 0) {
+while(int[2](flags) != 0) {
   flags = segment ancilla, input;
 }
 rz(pi - arccos(3 / 5)) input;

--- a/examples/scqec.qasm
+++ b/examples/scqec.qasm
@@ -14,9 +14,9 @@ const n = d^2;       // number of code qubits
 
 uint[32] failures;  // number of observed failures
 
-kernel zfirst creg[n - 1], int, int;
-kernel send creg[n -1 ], int, int, int;
-kernel zlast creg[n], int, int -> bit;
+kernel zfirst creg[n - 1], int[32], int[32];
+kernel send creg[n -1 ], int[32], int[32], int[32];
+kernel zlast creg[n], int[32], int[32] -> bit;
 
 qubit data[n];  // code qubits
 qubit ancilla[n - 1];  // syndrome qubits
@@ -96,10 +96,9 @@ for shot in [1: shots] {
   data_outcomes = measure data;
 
   outcome = zlast(data_outcomes, shot, d);
-  failures += int(outcome);
+  failures += int[1](outcome);
 }
 
 /* The ratio of "failures" to "shots" is our result.
  * The data can be logged by the external functions too.
  */
-

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -2,7 +2,7 @@
  * This example demonstrates the repeated use of fixed delays.
 */
 OPENQASM 3.0;
-include "stdgates.inc"; 
+include "stdgates.inc";
 
 length stride = 1us;            // time resolution of points taken
 const points = 50;              // number of points taken
@@ -35,8 +35,8 @@ for p in [0 : points-1] {
         c0 = measure %0;
         c1 = measure %1;
         // increment counts memories, if a 1 is seen
-        counts0 += int(c0);
-        counts1 += int(c1);
+        counts0 += int[1](c0);
+        counts1 += int[1](c1);
     }
     // log survival probability curve
     tabulate(counts0, shots, p);

--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -66,7 +66,7 @@ def counts_for_term(bit[2*n]:spec) qubit[n] -> uint[prec] {
     reset q;
     trial_circuit q;
     b = pauli_measurement(spec) q;
-    counts += int(b);
+    counts += int[1](b);
   }
   return counts;
 }
@@ -74,7 +74,7 @@ def counts_for_term(bit[2*n]:spec) qubit[n] -> uint[prec] {
 // Estimate the expected energy
 def estimate_energy qubit[n]:q -> fixed[prec,prec] {
   fixed[prec, prec] energy;
-  uint npaulis = get_npaulis();
+  uint[prec] npaulis = get_npaulis();
   for t in [0:npaulis-1] {
     bit spec[2*n] = get_pauli(t);
     uint[prec] counts;


### PR DESCRIPTION
Closes https://github.com/Qiskit/openqasm/issues/114 by adding default size values to variables in examples where not specified. The Qasm3 specification requires that sizes be defined for all variables. We may wish to define default sizes (for instance, 32 bits for `int`) in the future.