### PR TITLE
Change physical qubit identifier

### DIFF
--- a/examples/cphase.qasm
+++ b/examples/cphase.qasm
@@ -1,4 +1,4 @@
-gate cphase(angle[32]: θ) a, b
+gate cphase(θ) a, b
 {
   U(0, 0, θ / 2) a;
   CX a, b;

--- a/examples/dd.qasm
+++ b/examples/dd.qasm
@@ -6,22 +6,22 @@ OPENQASM 3.0;
 include "stdgates.inc";
 
 stretch s;
-length start_stretch = -0.5 * lengthof({x %0;}) + s;
-length middle_stretch = -0.5 * lengthof({x %0;}) - 5 * lengthof({y %0;}) + s;
-length end_stretch = -0.5 * lengthof({y %0;}) + s;
+length start_stretch = -0.5 * lengthof({x %q0;}) + s;
+length middle_stretch = -0.5 * lengthof({x %q0;}) - 5 * lengthof({y %q0;}) + s;
+length end_stretch = -0.5 * lengthof({y %q0;}) + s;
 
 boxas dd_circ {
-  delay[start_stretch] %0;
-  x %0;
-  delay[middle_stretch] %0;
-  y %0;
-  delay[middle_stretch] %0;
-  x %0;
-  delay[middle_stretch] %0;
-  y %0;
-  delay[end_stretch] %0;
+  delay[start_stretch] %q0;
+  x %q0;
+  delay[middle_stretch] %q0;
+  y %q0;
+  delay[middle_stretch] %q0;
+  x %q0;
+  delay[middle_stretch] %q0;
+  y %q0;
+  delay[end_stretch] %q0;
 
-  cx %2, %3;
-  cx %1, %2;
-  u %3;
+  cx %q2, %q3;
+  cx %q1, %q2;
+  u %q3;
 }

--- a/examples/dd.qasm
+++ b/examples/dd.qasm
@@ -6,22 +6,22 @@ OPENQASM 3.0;
 include "stdgates.inc";
 
 stretch s;
-length start_stretch = -0.5 * lengthof({x %q0;}) + s;
-length middle_stretch = -0.5 * lengthof({x %q0;}) - 5 * lengthof({y %q0;}) + s;
-length end_stretch = -0.5 * lengthof({y %q0;}) + s;
+length start_stretch = -0.5 * lengthof({x $0;}) + s;
+length middle_stretch = -0.5 * lengthof({x $0;}) - 5 * lengthof({y $0;}) + s;
+length end_stretch = -0.5 * lengthof({y $0;}) + s;
 
 boxas dd_circ {
-  delay[start_stretch] %q0;
-  x %q0;
-  delay[middle_stretch] %q0;
-  y %q0;
-  delay[middle_stretch] %q0;
-  x %q0;
-  delay[middle_stretch] %q0;
-  y %q0;
-  delay[end_stretch] %q0;
+  delay[start_stretch] $0;
+  x $0;
+  delay[middle_stretch] $0;
+  y $0;
+  delay[middle_stretch] $0;
+  x $0;
+  delay[middle_stretch] $0;
+  y $0;
+  delay[end_stretch] $0;
 
-  cx %q2, %q3;
-  cx %q1, %q2;
-  u %q3;
+  cx $2, $3;
+  cx $1, $2;
+  u $3;
 }

--- a/examples/defcal.qasm
+++ b/examples/defcal.qasm
@@ -1,36 +1,36 @@
 defcalgrammar "openpulse";
 
-defcal x %0 {
-   play drive(%0), gaussian(...);
+defcal x %q0 {
+   play drive(%q0), gaussian(...);
 }
 
-defcal x %1 {
-  play drive(%1), gaussian(...);
+defcal x %q1 {
+  play drive(%q1), gaussian(...);
 }
 
-defcal rz(angle[20]:theta) %q {
-  shift_phase drive(%q), -theta;
+defcal rz(angle[20]:theta) q {
+  shift_phase drive(q), -theta;
 }
 
-defcal measure %0 -> bit {
+defcal measure %q0 -> bit {
   complex[int[24]] iq;
   bit state;
   complex[int[12]] k0[1024] = [i0 + q0*j, i1 + q1*j, i2 + q2*j, ...];
-  play measure(%0), flat_top_gaussian(...);
-  iq = capture acquire(%0), 2048, kernel(k0);
+  play measure(%q0), flat_top_gaussian(...);
+  iq = capture acquire(%q0), 2048, kernel(k0);
   return threshold(iq, 1234);
 }
 
-defcal zx90_ix %0, %1 {
-  play drive(%0, "cr1"), flat_top_gaussian(...);  // uses a non-default
-                                                  // frame labeled "cr1"
+defcal zx90_ix %q0, %q1 {
+  play drive(%q0, "cr1"), flat_top_gaussian(...);  // uses a non-default
+                                                   // frame labeled "cr1"
 }
 
-defcal cx %0, %1 {
-  zx90_ix %0, %1;
-  x %0;
-  shift_phase drive(%0, "cr1");
-  zx90_ix %0, %1;
-  x %0;
-  x %1;
+defcal cx %q0, %q1 {
+  zx90_ix %q0, %q1;
+  x %q0;
+  shift_phase drive(%q0, "cr1");
+  zx90_ix %q0, %q1;
+  x %q0;
+  x %q1;
 }

--- a/examples/defcal.qasm
+++ b/examples/defcal.qasm
@@ -1,36 +1,36 @@
 defcalgrammar "openpulse";
 
-defcal x %q0 {
-   play drive(%q0), gaussian(...);
+defcal x $0 {
+   play drive($0), gaussian(...);
 }
 
-defcal x %q1 {
-  play drive(%q1), gaussian(...);
+defcal x $1 {
+  play drive($1), gaussian(...);
 }
 
-defcal rz(angle[20]:theta) q {
-  shift_phase drive(q), -theta;
+defcal rz(angle[20]:theta) $q {
+  shift_phase drive($q), -theta;
 }
 
-defcal measure %q0 -> bit {
+defcal measure $0 -> bit {
   complex[int[24]] iq;
   bit state;
   complex[int[12]] k0[1024] = [i0 + q0*j, i1 + q1*j, i2 + q2*j, ...];
-  play measure(%q0), flat_top_gaussian(...);
-  iq = capture acquire(%q0), 2048, kernel(k0);
+  play measure($0), flat_top_gaussian(...);
+  iq = capture acquire($0), 2048, kernel(k0);
   return threshold(iq, 1234);
 }
 
-defcal zx90_ix %q0, %q1 {
-  play drive(%q0, "cr1"), flat_top_gaussian(...);  // uses a non-default
+defcal zx90_ix $0, $1 {
+  play drive($0, "cr1"), flat_top_gaussian(...);  // uses a non-default
                                                    // frame labeled "cr1"
 }
 
-defcal cx %q0, %q1 {
-  zx90_ix %q0, %q1;
-  x %q0;
-  shift_phase drive(%q0, "cr1");
-  zx90_ix %q0, %q1;
-  x %q0;
-  x %q1;
+defcal cx $0, $1 {
+  zx90_ix $0, $1;
+  x $0;
+  shift_phase drive($0, "cr1");
+  zx90_ix $0, $1;
+  x $0;
+  x $1;
 }

--- a/examples/defcal.qasm
+++ b/examples/defcal.qasm
@@ -23,7 +23,7 @@ defcal measure $0 -> bit {
 
 defcal zx90_ix $0, $1 {
   play drive($0, "cr1"), flat_top_gaussian(...);  // uses a non-default
-                                                   // frame labeled "cr1"
+                                                  // frame labeled "cr1"
 }
 
 defcal cx $0, $1 {

--- a/examples/pong.qasm
+++ b/examples/pong.qasm
@@ -5,28 +5,28 @@
  */
 defcalgrammar "openpulse";
 
-defcal pong(amp, duration) q {
+defcal pong(amp, duration) $q {
     play d0, gaussian(amp, duration)
 }
 
-defcal pong_cx(amp) q0, q1, q2 {
-    barrier q0, q1, q2;
-    cross-res(pi/4) 0, 1
-    x(pi) 0;  // this is a gatecal
-    cross-res(-pi/4) 0, 1;
-    glue[1]-pong(amp) q1;
-    glue[2]-pong(-amp) q1;
-    glue[1]-pong(amp) q1;
-    barrier q0, q1, q2;
+defcal pong_cx(amp) $q0, $q1, $q2 {
+    barrier $q0, $q1, $q2;
+    cross-res(pi/4) $q0, $q1
+    x(pi) $q0;  // this is a defcal
+    cross-res(-pi/4) $q0, $q1;
+    glue[1]-pong(amp) $q1;
+    glue[2]-pong(-amp) $q1;
+    glue[1]-pong(amp) $q1;
+    barrier $q0, $q1, $q2;
 }
 
-barrier %q0, %q1, %q2;
-glue[1]-delay[0] %q0;    // these stretchable delays would be inserted by a high-level scheduling pass.
-glue[1]-delay[0] %q1;    // it should be possible to write regular QASM using those ponged CNOTs
-glue[1]-delay[0] %q2;    // even if you don't care how the whole program is aligned (left of right)
-h %q0;
-pong(0.5, 10dt) %q0 - pong_cx(0.5) %q0, %q1, %q2;
-barrier %q0, %q1, %q2;
+barrier $0, $1, $2;
+glue[1]-delay[0] $0;    // these stretchable delays would be inserted by a high-level scheduling pass.
+glue[1]-delay[0] $1;    // it should be possible to write regular QASM using those ponged CNOTs
+glue[1]-delay[0] $2;    // even if you don't care how the whole program is aligned (left of right)
+h $0;
+pong(0.5, 10dt) $0 - pong_cx(0.5) $0, $1, $2;
+barrier $0, $1, $2;
 
 
 //boxto conditional, anonymous subroutine (named boxto not supported)

--- a/examples/pong.qasm
+++ b/examples/pong.qasm
@@ -5,28 +5,28 @@
  */
 defcalgrammar "openpulse";
 
-defcal pong(amp, duration) %q0 {
+defcal pong(amp, duration) q {
     play d0, gaussian(amp, duration)
 }
 
-defcal pong_cx(amp) %q0, %q1, %q2 {
-    barrier %q0, %q1, %q2;
+defcal pong_cx(amp) q0, q1, q2 {
+    barrier q0, q1, q2;
     cross-res(pi/4) 0, 1
     x(pi) 0;  // this is a gatecal
     cross-res(-pi/4) 0, 1;
-    glue[1]-pong(amp) %q2;
-    glue[2]-pong(-amp) %q2;
-    glue[1]-pong(amp) %q2;
-    barrier %q0, %q1, %q2;
+    glue[1]-pong(amp) q1;
+    glue[2]-pong(-amp) q1;
+    glue[1]-pong(amp) q1;
+    barrier q0, q1, q2;
 }
 
-barrier %0, %1, %2;
-glue[1]-delay[0] %0;    // these stretchable delays would be inserted by a high-level scheduling pass.
-glue[1]-delay[0] %1;    // it should be possible to write regular QASM using those ponged CNOTs
-glue[1]-delay[0] %2;    // even if you don't care how the whole program is aligned (left of right)
-h %0;
-pong(0.5, 10dt) %0 - pong_cx(0.5) %0, %1, %2;
-barrier %0, %1, %2;
+barrier %q0, %q1, %q2;
+glue[1]-delay[0] %q0;    // these stretchable delays would be inserted by a high-level scheduling pass.
+glue[1]-delay[0] %q1;    // it should be possible to write regular QASM using those ponged CNOTs
+glue[1]-delay[0] %q2;    // even if you don't care how the whole program is aligned (left of right)
+h %q0;
+pong(0.5, 10dt) %q0 - pong_cx(0.5) %q0, %q1, %q2;
+barrier %q0, %q1, %q2;
 
 
 //boxto conditional, anonymous subroutine (named boxto not supported)

--- a/examples/stdgates.inc
+++ b/examples/stdgates.inc
@@ -1,7 +1,7 @@
 // Standard gate library
 
 // phase gate (Z-rotation by lambda)
-gate phase(angle[32]:lambda) q { U(0, 0, lambda) q; }
+gate phase(lambda) q { U(0, 0, lambda) q; }
 // controlled-NOT
 gate CX c, t { ctrl @ U(pi, 0, pi) c, t; }
 gate cx c, t { CX c, t; }
@@ -24,26 +24,26 @@ gate t a { phase(pi/4) a; }
 // C3 gate: conjugate of sqrt(S)
 gate tdg a { phase(-pi/4) a; }
 // Rotation around X-axis
-gate rx(angle[32]:theta) a { U(theta, -pi / 2, pi / 2) a; }
+gate rx(theta) a { U(theta, -pi / 2, pi / 2) a; }
 // rotation around Y-axis
-gate ry(angle[32]:theta) a { U(theta, 0, 0) a; }
+gate ry(theta) a { U(theta, 0, 0) a; }
 // rotation around Z axis
-gate rz(angle[32]:phi) a { phase(phi) a; }
+gate rz(phi) a { phase(phi) a; }
 // controlled-Phase
 gate cz a, b { h b; cx a, b; h b; }
 // controlled-Y
 gate cy a, b { sdg b; cx a, b; s b; }
 // controlled-H
 gate ch a, b {
-  h b; 
+  h b;
   sdg b;
   cx a, b;
-  h b; 
+  h b;
   t b;
   cx a, b;
-  t b; s a; 
-  h b; 
-  s b; 
+  t b; s a;
+  h b;
+  s b;
   x b;
 }
 // Toffoli
@@ -52,13 +52,13 @@ gate ccx a, b, c
   h c;
   cx b, c;
   tdg c;
-  cx a, c; 
+  cx a, c;
   t c;
-  cx b, c; 
+  cx b, c;
   tdg c;
-  cx a, c; 
+  cx a, c;
   t b; t c; h c;
-  cx a, b; 
+  cx a, b;
   t a; tdg b;
   cx a, b;
 }
@@ -70,7 +70,7 @@ gate cswap a, b, c
   cx c, b;
 }
 // controlled-rz
-gate crz(angle[32]:lambda) a, b
+gate crz(lambda) a, b
 {
   phase(lambda / 2) b;
   cx a, b;
@@ -78,7 +78,7 @@ gate crz(angle[32]:lambda) a, b
   cx a, b;
 }
 // controlled-phase
-gate cphase(angle[32]:lambda) a, b
+gate cphase(lambda) a, b
 {
   phase(lambda / 2) a;
   cx a, b;
@@ -87,7 +87,7 @@ gate cphase(angle[32]:lambda) a, b
   phase(lambda / 2) b;
 }
 // controlled-U
-gate cu(angle[32]:theta,angle[32]:phi,angle[32]:lambda) c, t
+gate cu(theta, phi, lambda) c, t
 {
   // implements controlled-U(theta,phi,lambda) with  target t and control c
   phase((lambda - phi)/2) t;

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -16,25 +16,25 @@ kernel tabulate(int[32], int[32], int[32]);
 bit c0, c1;
 
 // define a gate calibration for an X gate on any qubit
-defcal "openpulse" x q {
-   play drive(q), gaussian(100, 30, 5);
+defcal "openpulse" x $q {
+   play drive($q), gaussian(100, 30, 5);
 }
 
 for p in [0 : points-1] {
     for i in [1 : shots] {
         // start of a basic block
-        reset %q0;
-        reset %q1;
+        reset $0;
+        reset $1;
         // excite qubits
-        x %q0;
-        x %q1;
+        x $0;
+        x $1;
         // wait for a fixed time indicated by loop counter
-        delay[p * stride] %q0;
+        delay[p * stride] $0;
         // wait for a fixed time indicated by loop counters
-        delay[p * lengthof({x %q1;})];
+        delay[p * lengthof({x $1;})];
         // read out qubit states
-        c0 = measure %q0;
-        c1 = measure %q1;
+        c0 = measure $0;
+        c1 = measure $1;
         // increment counts memories, if a 1 is seen
         counts0 += int[1](c0);
         counts1 += int[1](c1);

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -15,8 +15,10 @@ kernel tabulate(int[32], int[32], int[32]);
 
 bit c0, c1;
 
+defcalgrammar "openpulse";
+
 // define a gate calibration for an X gate on any qubit
-defcal "openpulse" x $q {
+defcal x $q {
    play drive($q), gaussian(100, 30, 5);
 }
 

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -15,26 +15,26 @@ kernel tabulate(int[32], int[32], int[32]);
 
 bit c0, c1;
 
-// define a gate calibration for an X gate on qubit 1
-defcal "openpulse" x %0 {
-   play drive(%0), gaussian(100, 30, 5);
+// define a gate calibration for an X gate on any qubit
+defcal "openpulse" x q {
+   play drive(q), gaussian(100, 30, 5);
 }
 
 for p in [0 : points-1] {
     for i in [1 : shots] {
         // start of a basic block
-        reset %0;
-        reset %1;
+        reset %q0;
+        reset %q1;
         // excite qubits
-        x %0;
-        x %1;
+        x %q0;
+        x %q1;
         // wait for a fixed time indicated by loop counter
-        delay[p * stride] %0;
+        delay[p * stride] %q0;
         // wait for a fixed time indicated by loop counters
-        delay[p * lengthof({x %1;})];
+        delay[p * lengthof({x %q1;})];
         // read out qubit states
-        c0 = measure %0;
-        c1 = measure %1;
+        c0 = measure %q0;
+        c1 = measure %q1;
         // increment counts memories, if a 1 is seen
         counts0 += int[1](c0);
         counts1 += int[1](c1);

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -445,13 +445,13 @@ calibrationGrammarDeclaration
     ;
 
 calibrationDefinition
-    : 'defcal' calibrationGrammar? Identifier
+    : 'defcal' Identifier
     ( LPAREN calibrationArgumentList? RPAREN )? identifierList
     returnSignature? LBRACE .*? RBRACE  // for now, match anything inside body
     ;
 
 calibrationGrammar
-    : '"openpulse"' | StringLiteral // currently: pulse grammar string can be anything
+    : '"openpulse"' | StringLiteral  // currently: pulse grammar string can be anything
     ;
 
 calibrationArgumentList

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -194,7 +194,7 @@ quantumGateDefinition
     ;
 
 quantumGateSignature
-    : Identifier ( LPAREN classicalArgumentList? RPAREN )? identifierList
+    : ( Identifier | 'CX' | 'U' ) ( LPAREN classicalArgumentList? RPAREN )? identifierList
     ;
 
 quantumBlock
@@ -490,7 +490,7 @@ Integer : Digit+ ;
 
 fragment ValidUnicode : [\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}] ; // valid unicode chars
 fragment Letter : [A-Za-z] ;
-fragment FirstIdCharacter : '_' | '%' | ValidUnicode | Letter ;
+fragment FirstIdCharacter : '_' | '%q' | ValidUnicode | Letter ;
 fragment GeneralIdCharacter : FirstIdCharacter | Integer;
 
 Identifier : FirstIdCharacter GeneralIdCharacter* ;

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -490,7 +490,7 @@ Integer : Digit+ ;
 
 fragment ValidUnicode : [\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}] ; // valid unicode chars
 fragment Letter : [A-Za-z] ;
-fragment FirstIdCharacter : '_' | '%q' | ValidUnicode | Letter ;
+fragment FirstIdCharacter : '_' | '$' | ValidUnicode | Letter ;
 fragment GeneralIdCharacter : FirstIdCharacter | Integer;
 
 Identifier : FirstIdCharacter GeneralIdCharacter* ;

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -149,7 +149,7 @@ including stretches, will be resolved to constants.
 .. code-block:: c
 
        length a = 300ns;
-       length b = lengthof({x %q0});
+       length b = lengthof({x $0});
        stretch c;
        // stretchy length with min=300ns
        length d = a + 2 * c;
@@ -259,24 +259,24 @@ to properly take into account the finite length of each gate.
 .. code-block:: c
 
    stretch s, t;
-   length start_stretch = s - .5 * lengthof({x %q0;})
-   length middle_stretch = s - .5 * lengthof({x %q0;}) - .5 * lengthof({y %q0;}
-   length end_stretch = s - .5 * lengthof({y %q0;})
+   length start_stretch = s - .5 * lengthof({x $0;})
+   length middle_stretch = s - .5 * lengthof({x $0;}) - .5 * lengthof({y $0;}
+   length end_stretch = s - .5 * lengthof({y $0;})
 
-   delay[start_stretch] %q0;
-   x %q0;
-   delay[middle_stretch] %q0;
-   y %q0;
-   delay[middle_stretch] %q0;
-   x %q0;
-   delay[middle_stretch] %q0;
-   y %q0;
-   delay[end_stretch] %q0;
+   delay[start_stretch] $0;
+   x $0;
+   delay[middle_stretch] $0;
+   y $0;
+   delay[middle_stretch] $0;
+   x $0;
+   delay[middle_stretch] $0;
+   y $0;
+   delay[end_stretch] $0;
 
-   cx %q2, %q3;
-   delay[t] %q1;
-   cx %q1, %q2;
-   u %q3;
+   cx $2, $3;
+   delay[t] $1;
+   cx $1, $2;
+   u $3;
 
 Boxed expressions
 -----------------

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -149,7 +149,7 @@ including stretches, will be resolved to constants.
 .. code-block:: c
 
        length a = 300ns;
-       length b = lengthof({x %0});
+       length b = lengthof({x %q0});
        stretch c;
        // stretchy length with min=300ns
        length d = a + 2 * c;
@@ -259,24 +259,24 @@ to properly take into account the finite length of each gate.
 .. code-block:: c
 
    stretch s, t;
-   length start_stretch = s - .5 * lengthof({x %0;})
-   length middle_stretch = s - .5 * lengthof({x %0;}) - .5 * lengthof({y %0;}
-   length end_stretch = s - .5 * lengthof({y %0;})
+   length start_stretch = s - .5 * lengthof({x %q0;})
+   length middle_stretch = s - .5 * lengthof({x %q0;}) - .5 * lengthof({y %q0;}
+   length end_stretch = s - .5 * lengthof({y %q0;})
 
-   delay[start_stretch] %0;
-   x %0;
-   delay[middle_stretch] %0;
-   y %0;
-   delay[middle_stretch] %0;
-   x %0;
-   delay[middle_stretch] %0;
-   y %0;
-   delay[end_stretch] %0;
+   delay[start_stretch] %q0;
+   x %q0;
+   delay[middle_stretch] %q0;
+   y %q0;
+   delay[middle_stretch] %q0;
+   x %q0;
+   delay[middle_stretch] %q0;
+   y %q0;
+   delay[end_stretch] %q0;
 
-   cx %2, %3;
-   delay[t] %1;
-   cx %1, %2;
-   u %3;
+   cx %q2, %q3;
+   delay[t] %q1;
+   cx %q1, %q2;
+   u %q3;
 
 Boxed expressions
 -----------------

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -48,6 +48,7 @@ qubits. For instance, to define an equivalent `rz` calibration on qubits 0 and 1
 .. code-block:: c
 
    defcal rz(angle[20]:theta) $q { ... }
+   // we've defined ``rz`` on arbitrary physical qubits, so we can do:
    rz(3.14) $0;
    rz(3.14) $1;
 

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -27,8 +27,8 @@ instruction sequence on *physical* qubits, e.g.
 
 .. code-block:: c
 
-   defcal rz(angle[20]:theta) %q0 { ... }
-   defcal measure %q0 -> bit { ... }
+   defcal rz(angle[20]:theta) $0 { ... }
+   defcal measure $0 -> bit { ... }
 
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
@@ -38,28 +38,28 @@ interchangeable at the pulse level. Due to varying physical qubit
 properties a microcode definition of a gate on one qubit will not
 perform the equivalent operation on another qubit. To meaningfully
 describe gates as pulses we must bind operations to specific qubits.
-QASM achieves this by prefixing qubit references with ``%q`` to indicate
-a specific qubit on the device, e.g. ``%q2`` would refer to physical
+QASM achieves this by prefixing qubit references with ``$`` to indicate
+a specific qubit on the device, e.g. ``$2`` would refer to physical
 qubit 2.
 
-One can define a `defcal` using an arbitrary identifier, provided that gate is called using physical
+One can define a `defcal` using an arbitrary `$` identifier, provided that gate is called using physical
 qubits. For instance, to define an equivalent `rz` calibration on qubits 0 and 1, we could write
 
 .. code-block:: c
 
-   defcal rz(angle[20]:theta) q { ... }
-   rz(3.14) %q0;
-   rz(3.14) %q1;
+   defcal rz(angle[20]:theta) $q { ... }
+   rz(3.14) $0;
+   rz(3.14) $1;
 
 
 As a consequence of the need for specialization of operations on
-particular qubits, we expect the same symbol to be defined multiple
+particular qubits, the same symbol may be defined multiple
 times, e.g.
 
 .. code-block:: c
 
-   defcal h %q0 { ... }
-   defcal h %q1 { ... }
+   defcal h $0 { ... }
+   defcal h $1 { ... }
 
 and so forth. Some operations require further specialization on
 parameter values, so we also allow multiple declarations on the same
@@ -67,20 +67,20 @@ physical qubits with different parameter values, e.g.
 
 .. code-block:: c
 
-   defcal rx(pi) %q0 { ... }
-   defcal rx(pi / 2) %q0 { ... }
+   defcal rx(pi) $0 { ... }
+   defcal rx(pi / 2) $0 { ... }
 
 Given multiple definitions of the same symbol, the compiler will match
 the most specific definition found for a given operation. Thus, given,
 
-#. ``defcal rx(angle[20]:theta) q  ...``
+#. ``defcal rx(angle[20]:theta) $q  ...``
 
-#. ``defcal rx(angle[20]:theta) %q0  ...``
+#. ``defcal rx(angle[20]:theta) $0  ...``
 
-#. ``defcal rx(pi / 2) %q0  ...``
+#. ``defcal rx(pi / 2) $0  ...``
 
-the operation ``rx(pi/2) %q0`` would match to (3), ``rx(pi) %q0`` would
-match (2), ``rx(pi/2) %q1`` would match (1).
+the operation ``rx(pi/2) $0`` would match to (3), ``rx(pi) $0`` would
+match (2), ``rx(pi/2) $1`` would match (1).
 
 Users specify the grammar used inside ``defcal`` blocks with a ``defcalgrammar "name"`` declaration, or by
 an optional grammar string in a ``defcal`` definition, e.g.
@@ -88,7 +88,7 @@ an optional grammar string in a ``defcal`` definition, e.g.
 .. code-block:: c
 
    defcalgrammar "openpulse";
-   defcal "openpulse" measure %q0 -> bit { ... }
+   defcal "openpulse" measure $0 -> bit { ... }
 
 are two equivalent ways to specify that the ``measure`` definition uses the ``"openpulse"`` grammar.
 

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -27,8 +27,8 @@ instruction sequence on *physical* qubits, e.g.
 
 .. code-block:: c
 
-   defcal rz(angle[20]:theta) %q { ... }
-   defcal measure %q -> bit { ... }
+   defcal rz(angle[20]:theta) %q0 { ... }
+   defcal measure %q0 -> bit { ... }
 
 We distinguish gate and measurement definitions by the presence of a
 return value type in the latter case, analogous to the subroutine syntax
@@ -38,9 +38,19 @@ interchangeable at the pulse level. Due to varying physical qubit
 properties a microcode definition of a gate on one qubit will not
 perform the equivalent operation on another qubit. To meaningfully
 describe gates as pulses we must bind operations to specific qubits.
-QASM achieves this by prefixing qubit references with ``%`` to indicate
-a specific qubit on the device, e.g. ``%2`` would refer to physical
-qubit 2, while ``%q`` is an unbound reference to a physical qubit.
+QASM achieves this by prefixing qubit references with ``%q`` to indicate
+a specific qubit on the device, e.g. ``%q2`` would refer to physical
+qubit 2.
+
+One can define a `defcal` using an arbitrary identifier, provided that gate is called using physical
+qubits. For instance, to define an equivalent `rz` calibration on qubits 0 and 1, we could write
+
+.. code-block:: c
+
+   defcal rz(angle[20]:theta) q { ... }
+   rz(3.14) %q0;
+   rz(3.14) %q1;
+
 
 As a consequence of the need for specialization of operations on
 particular qubits, we expect the same symbol to be defined multiple
@@ -48,8 +58,8 @@ times, e.g.
 
 .. code-block:: c
 
-   defcal h %0 { ... }
-   defcal h %1 { ... }
+   defcal h %q0 { ... }
+   defcal h %q1 { ... }
 
 and so forth. Some operations require further specialization on
 parameter values, so we also allow multiple declarations on the same
@@ -57,20 +67,20 @@ physical qubits with different parameter values, e.g.
 
 .. code-block:: c
 
-   defcal rx(pi) %0 { ... }
-   defcal rx(pi / 2) %0 { ... }
+   defcal rx(pi) %q0 { ... }
+   defcal rx(pi / 2) %q0 { ... }
 
 Given multiple definitions of the same symbol, the compiler will match
 the most specific definition found for a given operation. Thus, given,
 
-#. ``defcal rx(angle[20]:theta) %q  ...``
+#. ``defcal rx(angle[20]:theta) q  ...``
 
-#. ``defcal rx(angle[20]:theta) %0  ...``
+#. ``defcal rx(angle[20]:theta) %q0  ...``
 
-#. ``defcal rx(pi / 2) %0  ...``
+#. ``defcal rx(pi / 2) %q0  ...``
 
-the operation ``rx(pi/2) %0`` would match to (3), ``rx(pi) %0`` would
-match (2), ``rx(pi/2) %1`` would match (1).
+the operation ``rx(pi/2) %q0`` would match to (3), ``rx(pi) %q0`` would
+match (2), ``rx(pi/2) %q1`` would match (1).
 
 Users specify the grammar used inside ``defcal`` blocks with a ``defcalgrammar "name"`` declaration, or by
 an optional grammar string in a ``defcal`` definition, e.g.
@@ -78,7 +88,7 @@ an optional grammar string in a ``defcal`` definition, e.g.
 .. code-block:: c
 
    defcalgrammar "openpulse";
-   defcal "openpulse" measure %q -> bit { ... }
+   defcal "openpulse" measure %q0 -> bit { ... }
 
 are two equivalent ways to specify that the ``measure`` definition uses the ``"openpulse"`` grammar.
 

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -83,15 +83,15 @@ the most specific definition found for a given operation. Thus, given,
 the operation ``rx(pi/2) $0`` would match to (3), ``rx(pi) $0`` would
 match (2), ``rx(pi/2) $1`` would match (1).
 
-Users specify the grammar used inside ``defcal`` blocks with a ``defcalgrammar "name"`` declaration, or by
-an optional grammar string in a ``defcal`` definition, e.g.
+Users specify the grammar used inside ``defcal`` blocks with a ``defcalgrammar "name"`` declaration.
+For instance,
 
 .. code-block:: c
 
    defcalgrammar "openpulse";
-   defcal "openpulse" measure $0 -> bit { ... }
 
-are two equivalent ways to specify that the ``measure`` definition uses the ``"openpulse"`` grammar.
+specifies that all `defcal`'s will use the "openpulse" grammar.
+
 
 Note that ``defcal`` and ``gate`` communicate orthogonal information to the compiler. ``gate``'s
 define unitary transformation rules to the compiler. The compiler may

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -57,8 +57,8 @@ Physical Qubits
 ~~~~~~~~~~~~~~~
 
 While program qubits can be named, hardware qubits are referenced only
-by the syntax ``%q[NUM]``. For an ``n`` qubit system, we have physical qubit
-references given by ``%q0``, ``%q1``, ..., ``%qn``. These qubit types are
+by the syntax ``$[NUM]``. For an ``n`` qubit system, we have physical qubit
+references given by ``$0``, ``$1``, ..., ``$n``. These qubit types are
 used in lower parts of the compilation stack when emitting physical
 circuits.
 
@@ -71,7 +71,7 @@ circuits.
    // Declare a qubit array with 20 qubits
    qubit qubit_array[20];
    // CNOT gate between physical qubits 0 and 1
-   CX %q0, %q1;
+   CX $0, $1;
 
 Classical types
 ---------------

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -57,7 +57,8 @@ Physical Qubits
 ~~~~~~~~~~~~~~~
 
 While program qubits can be named, hardware qubits are referenced only
-by integers with the syntax ``%0``, ``%1``, ..., ``%n``. These qubit types are
+by the syntax ``%q[NUM]``. For an ``n`` qubit system, we have physical qubit
+references given by ``%q0``, ``%q1``, ..., ``%qn``. These qubit types are
 used in lower parts of the compilation stack when emitting physical
 circuits.
 
@@ -70,7 +71,7 @@ circuits.
    // Declare a qubit array with 20 qubits
    qubit qubit_array[20];
    // CNOT gate between physical qubits 0 and 1
-   CX %0, %1;
+   CX %q0, %q1;
 
 Classical types
 ---------------


### PR DESCRIPTION
Use `$0, $1, ..., $n` as physical qubit identifiers. This avoids a clash w/ the modulo operator `%`.