### PR TITLE
subroutineCall should always have parentheses

### DIFF
--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -73,7 +73,7 @@ def counts_for_term(bit[2*n]:spec) qubit[n]:q -> uint[prec] {
 // Estimate the expected energy
 def estimate_energy qubit[n]:q -> fixed[prec,prec] {
   fixed[prec, prec] energy;
-  uint[prec] npaulis = get_npaulis;
+  uint[prec] npaulis = get_npaulis();
   for t in [0:npaulis-1] {
     bit spec[2*n] = get_pauli(t);
     uint[prec] counts;

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -388,7 +388,7 @@ subroutineBlock
 
 // if have subroutine w/ out args, is ambiguous; may get matched as identifier
 subroutineCall
-    : Identifier ( LPAREN expressionList? RPAREN )? expressionList
+    : Identifier LPAREN expressionList? RPAREN expressionList
     ;
 
 /* Directives */


### PR DESCRIPTION
[Current grammar of `subroutineCall`](https://github.com/Qiskit/openqasm/blob/02e62e91509fad3ff480be91329f740ea85bbea6/source/grammar/qasm3.g4#L390-L392) allows not to have parenthesis.

```
// if have subroutine w/ out args, is ambiguous; may get matched as identifier
subroutineCall
    : Identifier ( LPAREN expressionList? RPAREN )? expressionList
    ;
```

As commented there, if no argument exists, parser cannot distinguish a subroutine call with a normal variable (`expressionTerminator->Identifier`).

```
expressionTerminator
    : Constant
    | MINUS? ( Integer | RealNumber )
    | Identifier
    | StringLiteral
    | timingTerminator
    ;
```

For example, this qasm file is parsed wrongly.
```
OPENQASM 3;
include "stdgates.inc";
const n = 1;
const m = n - 1;
```
Its tree of `const m = n - 1` is
```
  statement
    classicalDeclarationStatement
      constantDeclaration
        const
        equalsAssignmentList
          m
          equalsExpression
            =
            expression
              subroutineCall
                n
                expressionList
                  expression
                    -
                    expression
                      expressionTerminator
                        1
      ;
```

`n` is recognized as `subroutineCall` though it is a constant variable. 

To parse correctly, parentheses are always necessary for a subroutine call even if it does not have any arguments.