### PR TITLE
[ANTLR] prioritize "b[i]" than "a && b" in "a && b[i]"

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -272,10 +272,10 @@ expressionStatement
     ;
 
 expression
-    : expression binaryOperator expression
+    : expression LBRACKET expression RBRACKET
+    | expression binaryOperator expression
     | unaryOperator expression
     | expression incrementor
-    | expression LBRACKET expression RBRACKET
     | LPAREN expression RPAREN
     | membershipTest
     | builtInCall


### PR DESCRIPTION
Currently, binary operation is prioritized than index access.
```
expression
    : expression binaryOperator expression
    ...
    | expression LBRACKET expression RBRACKET
    ...
    ;
```

This causes wrong parse results. For example, this outputs the following tree for `a && b[i];`
```
  statement
    expressionStatement
      expression
        expression
          expression
            expressionTerminator
              a
          binaryOperator
            &&
          expression
            expressionTerminator
              b
        [
        expression
          expressionTerminator
            i
        ]
      ;
```
This tree means `(((a) && (b))[i]);`. This  tree should be as follows:
```
  statement
    expressionStatement
      expression
        expression
          expressionTerminator
            a
        binaryOperator
          &&
        expression
          expression
            expressionTerminator
              b
          [
          expression
            expressionTerminator
              i
          ]
      ;
```
This tree means  `((a) && ((b)[i]));`, which is generated just by replacing the order of rules.
```
expression
    : expression LBRACKET expression RBRACKET
    ...
    | expression binaryOperator expression
    ...
    ;
```