### PR TITLE
Clarify passage on defined gate invocation w/r/t "same size"

### DIFF
--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -246,7 +246,7 @@ Gates must be declared before use and
 cannot call themselves. The statement ``name(params) qargs;`` applies the gate,
 and the variable parameters ``params`` can have any numeric type.
 
-The gate can be applied to any combination of qubits and quantum registers. Quantum registers must be of equivalent size. This is shown in the following example.
+The gate can be applied to any combination of qubit registers *of the same size*, as shown in the following example.
 which latter are *of the same size*, as shown in the following example.
 
 The quantum circuit given by

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -247,7 +247,6 @@ cannot call themselves. The statement ``name(params) qargs;`` applies the gate,
 and the variable parameters ``params`` can have any numeric type.
 
 The gate can be applied to any combination of qubit registers *of the same size*, as shown in the following example.
-which latter are *of the same size*, as shown in the following example.
 
 The quantum circuit given by
 

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -234,14 +234,22 @@ of the gate definition.
 Only built-in gate statements, calls to previously defined gates, and
 timing directives can appear in ``body``. For example, it is not valid to
 declare a classical register in a gate body. Looping constructs over these quantum
-statements are valid. The statements in the body
+statements are valid.
+
+The statements in the body
 can only refer to the symbols given in the parameter or argument list,
-and these symbols are scoped only to the subroutine body. An empty body
-corresponds to the identity gate. Gates must be declared before use and
-cannot call themselves. The statement ``name(params) qargs;`` applies the gate, and the variable
-parameters ``params`` can have any numeric type. The gate can be applied to any
-combination of qubits and quantum registers *of the same size* as shown
-in the following example. The quantum circuit given by
+and these symbols are scoped only to the subroutine body.
+
+An empty body corresponds to the identity gate.
+
+Gates must be declared before use and
+cannot call themselves. The statement ``name(params) qargs;`` applies the gate,
+and the variable parameters ``params`` can have any numeric type.
+
+The gate can be applied to any combination of qubits and quantum registers,
+which latter are *of the same size*, as shown in the following example.
+
+The quantum circuit given by
 
 .. code-block:: c
 
@@ -254,13 +262,14 @@ in the following example. The quantum circuit given by
    qubit qr2[3];
    qubit qr3[2];
    g qr0[0], qr1, qr2[0], qr3; // ok
-   g qr0[0], qr2, qr1[0], qr3; // error!
+   g qr0[0], qr2, qr1[0], qr3; // error! qr2 and qr3 differ in size
 
 has a second-to-last line that means
 
-.. code-block:: c
+.. code-block:: prolog
 
-   // FIXME: insert translation of algorithmic block from TeX source.
+   for j ← 0, 1 do
+       g qr0[0],qr1[j],qr2[0],qr3[j];
 
 We provide this so that user-defined gates can be applied in parallel
 like the built-in gates.

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -265,7 +265,11 @@ The quantum circuit given by
 
 has a second-to-last line that means
 
-.. code-block:: prolog
+.. code-block:: c
+
+   // FIXME: insert translation of algorithmic block from TeX source.
+
+.. code-block:: c
 
    for j ← 0, 1 do
        g qr0[0],qr1[j],qr2[0],qr3[j];

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -269,8 +269,6 @@ has a second-to-last line that means
 
    // FIXME: insert translation of algorithmic block from TeX source.
 
-.. code-block:: c
-
    for j ← 0, 1 do
        g qr0[0],qr1[j],qr2[0],qr3[j];
 

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -246,7 +246,7 @@ Gates must be declared before use and
 cannot call themselves. The statement ``name(params) qargs;`` applies the gate,
 and the variable parameters ``params`` can have any numeric type.
 
-The gate can be applied to any combination of qubits and quantum registers,
+The gate can be applied to any combination of qubits and quantum registers. Quantum registers must be of equivalent size. This is shown in the following example.
 which latter are *of the same size*, as shown in the following example.
 
 The quantum circuit given by


### PR DESCRIPTION
A passage in **Hierarchically defined unitary gates** inherited from _Open Quantum Assembly Language_ was confusing.

This PR clarifies the text an example.

Incidentally, the accompanying pseudocode highlights nicely if declared "prolog" instead of "c".