### PR TITLE
Add Travis CI for ANTLR tests

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,4 @@
+# basic Travis script to run ANTLR CI tests for OpenQASM
+language: python
+python: 3.7
+script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -7,6 +7,6 @@ before_script:
   - cd /usr/local/lib
   - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
-  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
+  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'
   - antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,9 +3,10 @@ language: python
 python: 3.7
 install:
   - pip install -r requirements.txt
+before_script:
   - cd /usr/local/lib
   - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
-  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'
-before_script: antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
+  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
+  - antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,4 +1,5 @@
 # basic Travis script to run ANTLR CI tests for OpenQASM
 language: python
 python: 3.7
+install: "pip install -r requirements.txt"
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,10 +3,10 @@ language: python
 python: 3.7
 install:
   - pip install -r requirements.txt
-before_script:
+before_install:
   - cd /usr/local/lib
   - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
-  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'
-  - antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
-script: pytest
+script:
+  - java -jar /usr/local/lib/antlr-4.9.2-complete.jar -Dlanguage=Python3 source/grammar/qasm3.g4
+  - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,7 @@ language: python
 python: 3.7
 install:
   - pip install -r requirements.txt
-before_install:
+before_script:
   - cd /usr/local/lib
   - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,7 @@ python: 3.7
 install:
   - pip install -r requirements.txt
 before_script:
-  - cd /usr/local/lib
-  - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
+  - sudo curl https://www.antlr.org/download/antlr-4.9.2-complete.jar -o /usr/local/lib/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
 script:
   - java -jar /usr/local/lib/antlr-4.9.2-complete.jar -Dlanguage=Python3 source/grammar/qasm3.g4

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,11 @@
 # basic Travis script to run ANTLR CI tests for OpenQASM
 language: python
 python: 3.7
-install: "pip install -r requirements.txt"
+install:
+  - pip install -r requirements.txt
+  - cd /usr/local/lib
+  - curl -O https://www.antlr.org/download/antlr-4.9-complete.jar
+  - export CLASSPATH=".:/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH"
+  - alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
 before_script: antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,12 @@
-# basic Travis script to run ANTLR CI tests for OpenQASM
+# Travis script to run ANTLR CI tests for OpenQASM
 language: python
 python: 3.7
 install: pip install -r requirements.txt
 before_script:
+  # install antlr
   - sudo curl https://www.antlr.org/download/antlr-4.9.2-complete.jar -o /usr/local/lib/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
 script:
-  - alias antlr4="java -jar /usr/local/lib/antlr-4.9.2-complete.jar"
-  - antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
+  # generate antlr files and then run tests
+  - java -jar /usr/local/lib/antlr-4.9.2-complete.jar -Dlanguage=Python3 source/grammar/qasm3.g4
   - pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,4 +2,5 @@
 language: python
 python: 3.7
 install: "pip install -r requirements.txt"
+before_script: antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -4,8 +4,8 @@ python: 3.7
 install:
   - pip install -r requirements.txt
   - cd /usr/local/lib
-  - curl -O https://www.antlr.org/download/antlr-4.9-complete.jar
-  - export CLASSPATH=".:/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH"
-  - alias antlr4='java -Xmx500M -cp "/usr/local/lib/antlr-4.9-complete.jar:$CLASSPATH" org.antlr.v4.Tool'
+  - sudo curl -O https://www.antlr.org/download/antlr-4.9.2-complete.jar
+  - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
+  - alias antlr4='java -jar /usr/local/lib/antlr-4.9.2-complete.jar'
 before_script: antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
 script: pytest

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,11 +1,11 @@
 # basic Travis script to run ANTLR CI tests for OpenQASM
 language: python
 python: 3.7
-install:
-  - pip install -r requirements.txt
+install: pip install -r requirements.txt
 before_script:
   - sudo curl https://www.antlr.org/download/antlr-4.9.2-complete.jar -o /usr/local/lib/antlr-4.9.2-complete.jar
   - export CLASSPATH=".:/usr/local/lib/antlr-4.9.2-complete.jar:$CLASSPATH"
 script:
-  - java -jar /usr/local/lib/antlr-4.9.2-complete.jar -Dlanguage=Python3 source/grammar/qasm3.g4
+  - alias antlr4="java -jar /usr/local/lib/antlr-4.9.2-complete.jar"
+  - antlr4 -Dlanguage=Python3 source/grammar/qasm3.g4
   - pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,5 @@
 sphinx
 sphinxcontrib-bibtex<2.0.0
 pylint
+antlr4-python3-runtime==4.9.2
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,5 +3,5 @@ sphinxcontrib-bibtex<2.0.0
 pylint
 
 # ANTLR requirements
-antlr4
+antlr4-python3-runtime
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,4 @@
 sphinx
 sphinxcontrib-bibtex<2.0.0
 pylint
-
-# ANTLR requirements
-antlr4-python3-runtime
 pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,7 @@
 sphinx
 sphinxcontrib-bibtex<2.0.0
 pylint
+
+# ANTLR requirements
+antlr4
+pytest

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,7 @@
 sphinx
 sphinxcontrib-bibtex<2.0.0
 pylint
+
+# antlr testing requirements
 antlr4-python3-runtime==4.9.2
 pytest

--- a/source/grammar/README.md
+++ b/source/grammar/README.md
@@ -1,11 +1,18 @@
 # OpenQasm 3.0 Grammar
 
-Grammar specification in [ANTLR](https://www.antlr.org/).
+Grammar specification in [ANTLR](https://www.antlr.org/). See `openqasm/source/grammar/qasm3.g4`.
 
-Generate ANTLR parser in Python: `antlr4 -Dlanguage=Python3 MYPATH/qasm3.g4`
+## Working with ANTLR
+To get up and running with ANTLR, follow these steps.
+1. Install ANTLR locally following these [instructions](https://github.com/antlr/antlr4/blob/master/doc/getting-started.md).
+2. Install the ANTLR Python runtime: `pip install antlr4-python3-runtime`.
+3. Generate the ANTLR parser files in Python: `antlr4 -Dlanguage=Python3 MYPATH/qasm3.g4`
+    - Note: This assumes you set the `antlr4` alias on installation.
+4. You can now use the generated files to parse qasm3 code! See, for instance, the method `build_parse_tree()` in `openqasm/source/grammar/tests/test_grammar`.
 
-Run Tests
-    - Run the test suite: `pytest MYPATH/test_grammar.py` (or just `pytest`). The `test_grammar.py`
-    file is located at: `openqasm/source/grammar/tests/test_grammar.py`.
+## Run the Tests
+1. Make sure you are set up with ANTLR by following the steps above.
+2. Run the test suite: `pytest MYPATH/test_grammar.py` (or just `pytest`)
+    - `test_grammar.py` path: `openqasm/source/grammar/tests/test_grammar.py`.
     - Reference files at `openqasm/source/grammar/tests/outputs/`
     - Example files at `openqasm/examples/`

--- a/source/grammar/README.md
+++ b/source/grammar/README.md
@@ -12,7 +12,6 @@ To get up and running with ANTLR, follow these steps.
 
 ## Run the Tests
 1. Make sure you are set up with ANTLR by following the steps above.
-2. Run the test suite: `pytest MYPATH/test_grammar.py` (or just `pytest`)
-    - `test_grammar.py` path: `openqasm/source/grammar/tests/test_grammar.py`.
+2. From the root of the repository, run the test suite: `pytest openqasm/source/grammar/test_grammar.py` (or just `pytest .`)
     - Reference files at `openqasm/source/grammar/tests/outputs/`
     - Example files at `openqasm/examples/`

--- a/source/grammar/README.md
+++ b/source/grammar/README.md
@@ -5,7 +5,7 @@ Grammar specification in [ANTLR](https://www.antlr.org/).
 Generate ANTLR parser in Python: `antlr4 -Dlanguage=Python3 MYPATH/qasm3.g4`
 
 Run Tests
-    - Run the test suite: `python -m unittest MYPATH/test_grammar.py`. The `test_grammar.py` file is
-    located at: `openqasm/source/grammar/tests/test_grammar.py`.
+    - Run the test suite: `pytest MYPATH/test_grammar.py` (or just `pytest`). The `test_grammar.py`
+    file is located at: `openqasm/source/grammar/tests/test_grammar.py`.
     - Reference files at `openqasm/source/grammar/tests/outputs/`
     - Example files at `openqasm/examples/`

--- a/source/grammar/tests/test_grammar.py
+++ b/source/grammar/tests/test_grammar.py
@@ -1,7 +1,7 @@
-import unittest
 import io
 import os
 from contextlib import redirect_stderr
+import pytest
 
 import yaml
 
@@ -72,15 +72,15 @@ def build_parse_tree(input_str: str, using_file: bool = False) -> str:
 
         error = err.getvalue()
         if error:
-            print(input_str)
             raise Exception("Parse tree build failed. Error:\n" + error)
 
     return pretty_tree
 
-class TestGrammar(unittest.TestCase):
-    """Test the ANTLR grammar w/ python unittest."""
+class TestGrammar:
+    """Test the ANTLR grammar w/ pytest."""
 
-    def setUp(self):
+    @pytest.fixture(scope="function", autouse=True)
+    def setup(self):
         test_dir = os.path.dirname(os.path.abspath(__file__))  # tests/ dir
         root_dir = os.path.dirname(os.path.dirname(os.path.dirname(test_dir)))  # project root dir
         self.examples_path = os.path.join(root_dir, "examples/")
@@ -109,7 +109,7 @@ class TestGrammar(unittest.TestCase):
         parse_tree = build_parse_tree(qasm_source)
 
         reference = test_dict["reference"]
-        self.assertEqual(parse_tree, reference)
+        assert parse_tree == reference
 
     def test_header(self):
         """Test header."""
@@ -166,7 +166,3 @@ class TestGrammar(unittest.TestCase):
             example_file = os.path.join(self.examples_path, e)
             if os.path.isfile(example_file):
                 tree = build_parse_tree(example_file, using_file=True)
-
-
-if __name__ == "__main__":
-    unittest.main()


### PR DESCRIPTION
This PR adds CI support to the OpenQASM repo by verifying that new PR's pass the ANTLR tests. This, of course, requires that any updates to the specification are reflected in the example files.