### PR TITLE
Remove multi-variable list initialization

### DIFF
--- a/examples/adder.qasm
+++ b/examples/adder.qasm
@@ -17,7 +17,10 @@ gate unmaj a, b, c {
     cx a, b;
 }
 
-qubit cin[1], a[4], b[4], cout[1];
+qubit cin[1];
+qubit a[4];
+qubit b[4];
+qubit cout[1];
 bit ans[5];
 uint[4] a_in = 1;  // a = 0001
 uint[4] b_in = 15; // b = 1111

--- a/examples/msd.qasm
+++ b/examples/msd.qasm
@@ -103,7 +103,8 @@ def rus_level_0 qubit[10]:magic, qubit[3]:scratch {
  */
 def distill_and_buffer(int[32]:num) qubit[33]:work, qubit[buffer_size]:buffer {
   int[32] index;
-  bit success_0, success_1;
+  bit success_0;
+  bit success_1;
   let magic_lvl0 = work[0: 9];
   let magic_lvl1_0 = work[10: 19];
   let magic_lvl1_1 = work[20: 29];

--- a/examples/t1.qasm
+++ b/examples/t1.qasm
@@ -13,7 +13,8 @@ int[32] counts1 = 0;   // surviving |1> populations of qubits
 
 kernel tabulate(int[32], int[32], int[32]);
 
-bit c0, c1;
+bit c0;
+bit c1;
 
 defcalgrammar "openpulse";
 

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -47,7 +47,7 @@ classicalDeclarationStatement
     ;
 
 classicalAssignment
-    : indexIdentifier assignmentOperator ( expression | indexIdentifier )
+    : Identifier designator? ( assignmentOperator expression )?
     ;
 
 assignmentStatement : ( classicalAssignment | quantumMeasurementAssignment ) SEMICOLON ;
@@ -81,7 +81,7 @@ quantumType
     ;
 
 quantumDeclaration
-    : quantumType indexIdentifierList
+    : quantumType Identifier designator?
     ;
 
 quantumArgument
@@ -122,25 +122,25 @@ classicalType
     ;
 
 constantDeclaration
-    : 'const' equalsAssignmentList
+    : 'const' Identifier equalsExpression?
     ;
 
 // if multiple variables declared at once, either none are assigned or all are assigned
 // prevents ambiguity w/ qubit arguments in subroutine calls
 singleDesignatorDeclaration
-    : singleDesignatorType designator ( identifierList | equalsAssignmentList )
+    : singleDesignatorType designator Identifier equalsExpression?
     ;
 
 doubleDesignatorDeclaration
-    : doubleDesignatorType doubleDesignator ( identifierList | equalsAssignmentList )
+    : doubleDesignatorType doubleDesignator Identifier equalsExpression?
     ;
 
 noDesignatorDeclaration
-    : noDesignatorType ( identifierList | equalsAssignmentList )
+    : noDesignatorType Identifier equalsExpression?
     ;
 
 bitDeclaration
-    : bitType (indexIdentifierList | indexEqualsAssignmentList )
+    : bitType Identifier designator? equalsExpression?
     ;
 
 classicalDeclaration
@@ -177,10 +177,6 @@ indexIdentifier
 
 indexIdentifierList
     : ( indexIdentifier COMMA )* indexIdentifier
-    ;
-
-indexEqualsAssignmentList
-    : ( indexIdentifier equalsExpression COMMA)* indexIdentifier equalsExpression
     ;
 
 rangeDefinition
@@ -390,10 +386,6 @@ equalsExpression
 assignmentOperator
     : EQUALS
     | '+=' | '-=' | '*=' | '/=' | '&=' | '|=' | '~=' | '^=' | '<<=' | '>>='
-    ;
-
-equalsAssignmentList
-    : ( Identifier equalsExpression COMMA)* Identifier equalsExpression
     ;
 
 membershipTest

--- a/source/grammar/tests/outputs/alias.yaml
+++ b/source/grammar/tests/outputs/alias.yaml
@@ -1,7 +1,9 @@
 # indent w/ 2 spaces
 source: |
-  bit a[2], b[2];
-  qubit q1[5], q2[7];
+  bit a[2];
+  bit b[2];
+  qubit q1[5];
+  qubit q2[7];
   let q = q1 || q2;
   let c = a[0,1] || b[1:2];
   let qq = q1[1,3,4];
@@ -17,48 +19,53 @@ reference: |
           bitDeclaration
             bitType
               bit
-            indexIdentifierList
-              indexIdentifier
-                a
-                [
-                expressionList
-                  expression
-                    expressionTerminator
-                      2
-                ]
-              ,
-              indexIdentifier
-                b
-                [
-                expressionList
-                  expression
-                    expressionTerminator
-                      2
-                ]
+            a
+            designator
+              [
+              expression
+                expressionTerminator
+                  2
+              ]
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          bitDeclaration
+            bitType
+              bit
+            b
+            designator
+              [
+              expression
+                expressionTerminator
+                  2
+              ]
         ;
     globalStatement
       quantumDeclarationStatement
         quantumDeclaration
           quantumType
             qubit
-          indexIdentifierList
-            indexIdentifier
-              q1
-              [
-              expressionList
-                expression
-                  expressionTerminator
-                    5
-              ]
-            ,
-            indexIdentifier
-              q2
-              [
-              expressionList
-                expression
-                  expressionTerminator
-                    7
-              ]
+          q1
+          designator
+            [
+            expression
+              expressionTerminator
+                5
+            ]
+        ;
+    globalStatement
+      quantumDeclarationStatement
+        quantumDeclaration
+          quantumType
+            qubit
+          q2
+          designator
+            [
+            expression
+              expressionTerminator
+                7
+            ]
         ;
     statement
       aliasStatement

--- a/source/grammar/tests/outputs/assignment.yaml
+++ b/source/grammar/tests/outputs/assignment.yaml
@@ -1,6 +1,7 @@
 # indent w/ 2 spaces
 source: |
-  bit a[2], b[2];
+  bit a[2];
+  bit b[2];
   qubit q[3];
   int[10] x = 12;
   a[0] = b[1];
@@ -15,39 +16,40 @@ reference: |
           bitDeclaration
             bitType
               bit
-            indexIdentifierList
-              indexIdentifier
-                a
-                [
-                expressionList
-                  expression
-                    expressionTerminator
-                      2
-                ]
-              ,
-              indexIdentifier
-                b
-                [
-                expressionList
-                  expression
-                    expressionTerminator
-                      2
-                ]
+            a
+            designator
+              [
+              expression
+                expressionTerminator
+                  2
+              ]
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          bitDeclaration
+            bitType
+              bit
+            b
+            designator
+              [
+              expression
+                expressionTerminator
+                  2
+              ]
         ;
     globalStatement
       quantumDeclarationStatement
         quantumDeclaration
           quantumType
             qubit
-          indexIdentifierList
-            indexIdentifier
-              q
-              [
-              expressionList
-                expression
-                  expressionTerminator
-                    3
-              ]
+          q
+          designator
+            [
+            expression
+              expressionTerminator
+                3
+            ]
         ;
     statement
       classicalDeclarationStatement
@@ -61,24 +63,22 @@ reference: |
                 expressionTerminator
                   10
               ]
-            equalsAssignmentList
-              x
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    12
+            x
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  12
         ;
     statement
       assignmentStatement
         classicalAssignment
-          indexIdentifier
-            a
+          a
+          designator
             [
-            expressionList
-              expression
-                expressionTerminator
-                  0
+            expression
+              expressionTerminator
+                0
             ]
           assignmentOperator
             =
@@ -95,8 +95,7 @@ reference: |
     statement
       assignmentStatement
         classicalAssignment
-          indexIdentifier
-            x
+          x
           assignmentOperator
             +=
           expression

--- a/source/grammar/tests/outputs/declaration.yaml
+++ b/source/grammar/tests/outputs/declaration.yaml
@@ -1,10 +1,15 @@
 # indent w/ 2 spaces
 source: |
-  int[10] x, y;
-  qubit q1[6], q2;
-  bit b1[4]="0100", b2 = "1";
-  bool m=True, n=bool(b2);
-  const c = 5.5e3, d=5;
+  int[10] x;
+  int[10] y;
+  qubit q1[6];
+  qubit q2;
+  bit b1[4]="0100";
+  bit b2 = "1";
+  bool m=True;
+  bool n=bool(b2);
+  const c = 5.5e3;
+  const d=5;
   stretch s;
   stretch1 s1;
   stretch10 s10;
@@ -25,28 +30,41 @@ reference: |
                 expressionTerminator
                   10
               ]
-            identifierList
-              x
-              ,
-              y
+            x
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          singleDesignatorDeclaration
+            singleDesignatorType
+              int
+            designator
+              [
+              expression
+                expressionTerminator
+                  10
+              ]
+            y
         ;
     globalStatement
       quantumDeclarationStatement
         quantumDeclaration
           quantumType
             qubit
-          indexIdentifierList
-            indexIdentifier
-              q1
-              [
-              expressionList
-                expression
-                  expressionTerminator
-                    6
-              ]
-            ,
-            indexIdentifier
-              q2
+          q1
+          designator
+            [
+            expression
+              expressionTerminator
+                6
+            ]
+        ;
+    globalStatement
+      quantumDeclarationStatement
+        quantumDeclaration
+          quantumType
+            qubit
+          q2
         ;
     statement
       classicalDeclarationStatement
@@ -54,28 +72,31 @@ reference: |
           bitDeclaration
             bitType
               bit
-            indexEqualsAssignmentList
-              indexIdentifier
-                b1
-                [
-                expressionList
-                  expression
-                    expressionTerminator
-                      4
-                ]
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    "0100"
-              ,
-              indexIdentifier
-                b2
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    "1"
+            b1
+            designator
+              [
+              expression
+                expressionTerminator
+                  4
+              ]
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  "0100"
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          bitDeclaration
+            bitType
+              bit
+            b2
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  "1"
         ;
     statement
       classicalDeclarationStatement
@@ -83,49 +104,57 @@ reference: |
           noDesignatorDeclaration
             noDesignatorType
               bool
-            equalsAssignmentList
-              m
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    True
-              ,
-              n
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    builtInCall
-                      castOperator
-                        classicalType
-                          noDesignatorType
-                            bool
-                      (
-                      expressionList
-                        expression
-                          expressionTerminator
-                            b2
-                      )
+            m
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  True
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          noDesignatorDeclaration
+            noDesignatorType
+              bool
+            n
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  builtInCall
+                    castOperator
+                      classicalType
+                        noDesignatorType
+                          bool
+                    (
+                    expressionList
+                      expression
+                        expressionTerminator
+                          b2
+                    )
         ;
     statement
       classicalDeclarationStatement
         constantDeclaration
           const
-          equalsAssignmentList
-            c
-            equalsExpression
-              =
-              expression
-                expressionTerminator
-                  5.5e3
-            ,
-            d
-            equalsExpression
-              =
-              expression
-                expressionTerminator
-                  5
+          c
+          equalsExpression
+            =
+            expression
+              expressionTerminator
+                5.5e3
+        ;
+    statement
+      classicalDeclarationStatement
+        constantDeclaration
+          const
+          d
+          equalsExpression
+            =
+            expression
+              expressionTerminator
+                5
         ;
     statement
       classicalDeclarationStatement
@@ -134,8 +163,7 @@ reference: |
             noDesignatorType
               timingType
                 stretch
-            identifierList
-              s
+            s
         ;
     statement
       classicalDeclarationStatement
@@ -144,8 +172,7 @@ reference: |
             noDesignatorType
               timingType
                 stretch1
-            identifierList
-              s1
+            s1
         ;
     statement
       classicalDeclarationStatement
@@ -154,8 +181,7 @@ reference: |
             noDesignatorType
               timingType
                 stretch10
-            identifierList
-              s10
+            s10
         ;
     statement
       classicalDeclarationStatement
@@ -164,8 +190,7 @@ reference: |
             noDesignatorType
               timingType
                 stretch100
-            identifierList
-              s100
+            s100
         ;
     statement
       classicalDeclarationStatement
@@ -174,6 +199,5 @@ reference: |
             noDesignatorType
               timingType
                 stretch255
-            identifierList
-              s255
+            s255
         ;

--- a/source/grammar/tests/outputs/pragma.yaml
+++ b/source/grammar/tests/outputs/pragma.yaml
@@ -11,8 +11,7 @@ reference: |
         statement
           assignmentStatement
             classicalAssignment
-              indexIdentifier
-                __directive_info__
+              __directive_info__
               assignmentOperator
                 =
               expression

--- a/source/grammar/tests/outputs/sub_and_kern_call.yaml
+++ b/source/grammar/tests/outputs/sub_and_kern_call.yaml
@@ -11,33 +11,31 @@ reference: |
           bitDeclaration
             bitType
               bit
-            indexEqualsAssignmentList
-              indexIdentifier
-                x
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    subroutineCall
-                      sub_call
-                      (
-                      expressionList
-                        expression
-                          expressionTerminator
-                            10
-                        ,
-                        expression
-                          expressionTerminator
-                            "01"
-                      )
-                      expressionList
-                        expression
-                          expressionTerminator
-                            q1
-                        ,
-                        expression
-                          expressionTerminator
-                            q2
+            x
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  subroutineCall
+                    sub_call
+                    (
+                    expressionList
+                      expression
+                        expressionTerminator
+                          10
+                      ,
+                      expression
+                        expressionTerminator
+                          "01"
+                    )
+                    expressionList
+                      expression
+                        expressionTerminator
+                          q1
+                      ,
+                      expression
+                        expressionTerminator
+                          q2
         ;
     statement
       classicalDeclarationStatement
@@ -51,24 +49,23 @@ reference: |
                 expressionTerminator
                   2
               ]
-            equalsAssignmentList
-              y
-              equalsExpression
-                =
-                expression
-                  expressionTerminator
-                    kernelCall
-                      kern_call
-                      (
-                      expressionList
-                        expression
-                          expressionTerminator
-                            0.5
-                        ,
-                        expression
-                          expressionTerminator
-                            timingTerminator
-                              timingIdentifier
-                                10dt
-                      )
+            y
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  kernelCall
+                    kern_call
+                    (
+                    expressionList
+                      expression
+                        expressionTerminator
+                          0.5
+                      ,
+                      expression
+                        expressionTerminator
+                          timingTerminator
+                            timingIdentifier
+                              10dt
+                    )
         ;

--- a/source/grammar/tests/outputs/subroutine.yaml
+++ b/source/grammar/tests/outputs/subroutine.yaml
@@ -72,8 +72,7 @@ reference: |
                       expressionTerminator
                         10
                     ]
-                  identifierList
-                    result
+                  result
               ;
           returnStatement
             return

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -47,8 +47,8 @@ right circular shift, ``rotl`` and ``rotr``, respectively.
 
 .. code-block:: c
 
-   bit[8] a = "10001111";
-   bit[8] b = "01110000";
+   bit a[8] = "10001111";
+   bit b[8] = "01110000";
 
    a << 1; // Bit shift left produces "00011110"
    rotl(a, 2) // Produces "00111110"

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -258,7 +258,8 @@ to properly take into account the finite length of each gate.
 
 .. code-block:: c
 
-   stretch s, t;
+   stretch s;
+   stretch t;
    length start_stretch = s - .5 * lengthof({x $0;})
    length middle_stretch = s - .5 * lengthof({x $0;}) - .5 * lengthof({y $0;}
    length end_stretch = s - .5 * lengthof({y $0;})

--- a/source/language/insts.rst
+++ b/source/language/insts.rst
@@ -47,7 +47,7 @@ broadcasts to ``b[j] = measure a[j];`` for each index ``j`` into register ``a``.
 
    // Initialize, flip and measure an array of 10 qubits
    qubit qubits[10];
-   bit[10] bits;
+   bit bits[10];
    x qubits;
    bits = measure qubits;
 

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -51,7 +51,8 @@ follows
 
 .. code-block:: c
 
-   qubit q, r;
+   qubit q;
+   qubit r;
    c = measure q;
    c2 = measure r;
    bit result;
@@ -65,7 +66,8 @@ this
 
    const n = /* size of c + size of c2 */;
    kernel parity(bit[n]) -> bit;
-   qubit q, r;
+   qubit q;
+   qubit r;
    c = measure q;
    c2 = measure r;
    bit result;

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -16,11 +16,27 @@ sets with the addition of decimal numerals [0-9]. Variable identifiers may not
 override a reserved identifier.
 
 In addition to being assigned values within a program, all of the classical
-types can be initialized on declaration. Multiple comma-separated declarations
-can occur after the typename with optional assignment on declaration for each.
-Any classical variable or Boolean that is not explicitly initialized is
-undefined. Classical types can be mutually cast to one another using the
-typename.
+types can be initialized on declaration. Any classical variable or Boolean that is not explicitly
+initialized is undefined. Classical types can be mutually cast to one another using the typename.
+
+Declaration and initialization must be done one variable at a time for both quantum and classical
+types. Comma seperated declaration/initialization (``int x, y, z``) is NOT allowed for any type. For
+example, to declare a set of qubits one must do
+
+.. code-block:: c
+
+   qubit q0;
+   qubit q1;
+   qubit q2;
+
+and to declare a set of classical variables
+
+.. code-block:: c
+
+   int[32] x;
+   float[32] y = 5.5;
+   bit c[3];
+   bool my_bool = false;
 
 We use the notation ``s:m:f`` to denote the width and precision of fixed point numbers,
 where ``s`` is the number of sign bits, ``m`` is the number of integer bits, and ``f`` is the


### PR DESCRIPTION
Disallow list-based variable declaration and initialization such as `int[32] x, y, z;`. 

Require instead that each variable be declared in its own statement, ie
```
int[32] x;
int[32] y;
int[32] z;
```

This applies to classical and quantum types. ANTLR, tests and examples are updated accordingly.