### PR TITLE
qubit and bit declaration syntax 

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -82,6 +82,7 @@ quantumType
 
 quantumDeclaration
     : quantumType indexIdentifierList
+    | quantumType LBRACKET expressionList RBRACKET Identifier
     ;
 
 quantumArgument

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -142,6 +142,7 @@ noDesignatorDeclaration
 
 bitDeclaration
     : bitType (indexIdentifierList | indexEqualsAssignmentList )
+    | bitType LBRACKET expressionList RBRACKET Identifier
     ;
 
 classicalDeclaration

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -41,6 +41,6 @@ contents of the file were inserted at the location of the ``include`` statement.
    // First non-comment is a version string
    OPENQASM 3.0;
 
-   include "standard_gates.inc";
+   include "stdgates.qasm";
 
    // Rest of QASM program

--- a/source/language/comments.rst
+++ b/source/language/comments.rst
@@ -41,6 +41,6 @@ contents of the file were inserted at the location of the ``include`` statement.
    // First non-comment is a version string
    OPENQASM 3.0;
 
-   include "stdgates.qasm";
+   include "standard_gates.inc";
 
    // Rest of QASM program


### PR DESCRIPTION
Address #188 making available qubit and bit declaration syntax described in _OpenQASM 3_ as preferable.