### PR TITLE
[ANTLR] Small fixes

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -225,7 +225,7 @@ quantumInstruction
     ;
 
 quantumPhase
-    : 'gphase' LPAREN Identifier RPAREN
+    : 'gphase' LPAREN expression RPAREN
     ;
 
 quantumReset
@@ -333,6 +333,7 @@ expressionTerminator
     : Constant
     | Integer
     | RealNumber
+    | booleanLiteral
     | Identifier
     | StringLiteral
     | builtInCall
@@ -345,6 +346,10 @@ expressionTerminator
     | expressionTerminator incrementor
     ;
 /** End expression hierarchy **/
+
+booleanLiteral
+    : 'true' | 'false'
+    ;
 
 incrementor
     : '++'
@@ -429,8 +434,7 @@ controlDirective
     ;
 
 kernelDeclaration
-    : 'kernel' Identifier ( LPAREN classicalTypeList? RPAREN )? returnSignature?
-    classicalType? SEMICOLON
+    : 'kernel' Identifier ( LPAREN classicalTypeList? RPAREN )? returnSignature? SEMICOLON
     ;
 
 // if have kernel w/ out args, is ambiguous; may get matched as identifier
@@ -558,7 +562,7 @@ Integer : Digit+ ;
 
 fragment ValidUnicode : [\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}] ; // valid unicode chars
 fragment Letter : [A-Za-z] ;
-fragment FirstIdCharacter : '_' | '$' | ValidUnicode | Letter ;
+fragment FirstIdCharacter : '_' | ValidUnicode | Letter ;
 fragment GeneralIdCharacter : FirstIdCharacter | Integer;
 
 StretchN : 'stretch' Digit* ;

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -562,7 +562,7 @@ Integer : Digit+ ;
 
 fragment ValidUnicode : [\p{Lu}\p{Ll}\p{Lt}\p{Lm}\p{Lo}\p{Nl}] ; // valid unicode chars
 fragment Letter : [A-Za-z] ;
-fragment FirstIdCharacter : '_' | ValidUnicode | Letter ;
+fragment FirstIdCharacter : '_' | '$' | ValidUnicode | Letter ;
 fragment GeneralIdCharacter : FirstIdCharacter | Integer;
 
 StretchN : 'stretch' Digit* ;

--- a/source/grammar/tests/outputs/declaration.yaml
+++ b/source/grammar/tests/outputs/declaration.yaml
@@ -6,8 +6,9 @@ source: |
   qubit q2;
   bit[4] b1="0100";
   bit b2 = "1";
-  bool m=True;
+  bool m=true;
   bool n=bool(b2);
+  bool o=false;
   const c = 5.5e3;
   const d=5;
   stretch s;
@@ -105,7 +106,8 @@ reference: |
               =
               expression
                 expressionTerminator
-                  True
+                  booleanLiteral
+                    true
         ;
     statement
       classicalDeclarationStatement
@@ -129,6 +131,20 @@ reference: |
                         expressionTerminator
                           b2
                     )
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          noDesignatorDeclaration
+            noDesignatorType
+              bool
+            o
+            equalsExpression
+              =
+              expression
+                expressionTerminator
+                  booleanLiteral
+                    false
         ;
     statement
       classicalDeclarationStatement

--- a/source/grammar/tests/outputs/quantum_gate.yaml
+++ b/source/grammar/tests/outputs/quantum_gate.yaml
@@ -3,6 +3,7 @@ source: |
   gate test_gate(theta) a, b {
     reset a;
     barrier b;
+    gphase(-theta/2);
     CX a, b;
   }
 reference: |
@@ -39,6 +40,27 @@ reference: |
                 indexIdentifierList
                   indexIdentifier
                     b
+            ;
+          quantumStatement
+            quantumInstruction
+              quantumPhase
+                gphase
+                (
+                expression
+                  xOrExpression
+                    bitAndExpression
+                      bitShiftExpression
+                        additiveExpression
+                          multiplicativeExpression
+                            multiplicativeExpression
+                              expressionTerminator
+                                -
+                                expressionTerminator
+                                  theta
+                            /
+                            expressionTerminator
+                              2
+                )
             ;
           quantumStatement
             quantumInstruction

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -8,8 +8,7 @@ Types and Casting
 Generalities
 ------------
 
-Variable identifiers must begin with a letter [A-Za-z], an underscore, a
-percent sign, or an element from the Unicode character categories
+Variable identifiers must begin with a letter [A-Za-z], an underscore or an element from the Unicode character categories
 Lu/Ll/Lt/Lm/Lo/Nl :cite:`noauthorUnicodeNodate`. The set of permissible
 continuation characters consists of all members of the aforementioned character
 sets with the addition of decimal numerals [0-9]. Variable identifiers may not


### PR DESCRIPTION
Minor ANTLR fixes to close https://github.com/Qiskit/openqasm/issues/179, https://github.com/Qiskit/openqasm/issues/143 and https://github.com/Qiskit/openqasm/issues/142.

These handle `true/false` literals, fix a return type issue and allow `expression` type to be passed to `gphase`.

`%` is also eliminated as a valid identifier as it intersects with modulo. 