### PR TITLE
off-by-one in Physical Qubit section

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -74,7 +74,7 @@ Physical Qubits
 
 While program qubits can be named, hardware qubits are referenced only
 by the syntax ``$[NUM]``. For an ``n`` qubit system, we have physical qubit
-references given by ``$0``, ``$1``, ..., ``$n``. These qubit types are
+references given by ``$0``, ``$1``, ..., ``$n-1``. These qubit types are
 used in lower parts of the compilation stack when emitting physical
 circuits.
 


### PR DESCRIPTION
In a $N$ qubit system, each qubit is referred as `$0` to `$n-1`.