### PR TITLE
Change *List in Antlr grammar from left recursive to right recursive grammar

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -80,7 +80,7 @@ quantumArgument
     ;
 
 quantumArgumentList
-    : ( quantumArgument COMMA )* quantumArgument
+    : quantumArgument ( COMMA quantumArgument )* 
     ;
 
 /** Classical Types **/
@@ -157,7 +157,7 @@ classicalArgument
     ;
 
 classicalArgumentList
-    : ( classicalArgument COMMA )* classicalArgument
+    : classicalArgument ( COMMA classicalArgument )* 
     ;
 
 /** Aliasing **/
@@ -174,7 +174,7 @@ indexIdentifier
     ;
 
 indexIdentifierList
-    : ( indexIdentifier COMMA )* indexIdentifier
+    : indexIdentifier ( COMMA indexIdentifier )* 
     ;
 
 rangeDefinition
@@ -396,7 +396,7 @@ castOperator
     ;
 
 expressionList
-    : ( expression COMMA )* expression
+    : expression ( COMMA expression )* 
     ;
 
 equalsExpression


### PR DESCRIPTION
Currently, in qasm3.g4, we have something list grammar like:

```
quantumArgumentList
    : ( quantumArgument COMMA )* quantumArgument
    ;
```

Suggest to change to:
```
quantumArgumentList
    : quantumArgument ( COMMA quantumArgument )* 
    ;
```

This is because Antlr is an LL(*) parser. It performs better when we minimize number of look-aheads. In the old grammar, the parser does not know whether to match `( quantumArgument COMMA )*` or `quantumArgument` until it sees COMMA. In the new grammar, the parser will match `quantumArgument` first and then determine whether it needs to match `( COMMA quantumArgument )*` with a single look-ahead (LL(1)).

This applies to the follow lists:
- quantumArgumentList
- classicalArgumentList
- indexIdentifierList
- expressionList