### PR TITLE
Adding Input/output grammar and live spec description

### DIFF
--- a/examples/rus.qasm
+++ b/examples/rus.qasm
@@ -23,18 +23,18 @@ def segment qubit[2] anc, qubit psi -> bit[2] {
   return b;
 }
 
-qubit input;
+qubit input_qubit;
 qubit[2] ancilla;
 bit[2] flags = "11";
-bit output;
+bit output_qubit;
 
-reset input;
-h input;
+reset input_qubit;
+h input_qubit;
 
 // braces are optional in this case
 while(int[2](flags) != 0) {
-  flags = segment ancilla, input;
+  flags = segment ancilla, input_qubit;
 }
-rz(pi - arccos(3 / 5)) input;
-h input;
-output = measure input;  // should get zero
+rz(pi - arccos(3 / 5)) input_qubit;
+h input_qubit;
+output_qubit = measure input_qubit;  // should get zero

--- a/examples/varteleport.qasm
+++ b/examples/varteleport.qasm
@@ -18,14 +18,14 @@ def xprepare qubit q {
   h q;
 }
 
-qubit input;
-bit output;
+qubit input_qubit;
+bit output_qubit;
 qubit[2*n_pairs] q;
 
-xprepare input;
-rz(pi / 4) input;
+xprepare input_qubit;
+rz(pi / 4) input_qubit;
 
-let io = input;
+let io = input_qubit;
 for i in [0: n_pairs - 1] {
   let bp = q[2 * i, 2 * i + 1];
   bit[2] pf;
@@ -40,4 +40,4 @@ for i in [0: n_pairs - 1] {
 }
 
 h io;
-output = measure io;  // should get zero
+output_qubit = measure io;  // should get zero

--- a/source/bibliography.bib
+++ b/source/bibliography.bib
@@ -409,3 +409,14 @@
   journal={arXiv preprint arXiv:2007.12931},
   year={2020}
 }
+
+@article{peruzzo2014variational,
+  title={A variational eigenvalue solver on a photonic quantum processor},
+  author={Peruzzo, Alberto and McClean, Jarrod and Shadbolt, Peter and Yung, Man-Hong and Zhou, Xiao-Qi and Love, Peter J and Aspuru-Guzik, Al{\'a}n and O’brien, Jeremy L},
+  journal={Nature communications},
+  volume={5},
+  number={1},
+  pages={1--7},
+  year={2014},
+  publisher={Nature Publishing Group}
+}

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -9,7 +9,7 @@ program
     ;
 
 header
-    : version? include*
+    : version? include* io*
     ;
 
 version
@@ -18,6 +18,14 @@ version
 
 include
     : 'include' StringLiteral SEMICOLON
+    ;
+
+ioIdentifier
+    : 'input'
+    | 'output'
+    ;
+io
+    : ioIdentifier classicalType Identifier SEMICOLON
     ;
 
 globalStatement

--- a/source/grammar/tests/outputs/header.yaml
+++ b/source/grammar/tests/outputs/header.yaml
@@ -2,6 +2,9 @@
 source: |
   OPENQASM 3.0;
   include "std_gates.inc";
+  input angle[32] param1;
+  input angle[32] param2;
+  output bit result;
 reference: |
   program
     header
@@ -12,4 +15,40 @@ reference: |
       include
         include
         "std_gates.inc"
+        ;
+      io
+        ioIdentifier
+          input
+        classicalType
+          singleDesignatorType
+            angle
+          designator
+            [
+            expression
+              expressionTerminator
+                32
+            ]
+        param1
+        ;
+      io
+        ioIdentifier
+          input
+        classicalType
+          singleDesignatorType
+            angle
+          designator
+            [
+            expression
+              expressionTerminator
+                32
+            ]
+        param2
+        ;
+      io
+        ioIdentifier
+          output
+        classicalType
+          bitType
+            bit
+        result
         ;

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -69,8 +69,8 @@ variable:
 
 .. code-block:: c
 
-    input angle param1;
-    input angle param2;
+    input angle[32] param1;
+    input angle[32] param2;
     qubit q;
 
     // Build an ansatz using the above free parameters, eg.

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -62,7 +62,7 @@ performs a measurement in a basis given by an input parameter:
     result = measure q;
 
 For a second example, consider the Variable Quantum Eigensolver (VQE) algorithm 
-:cite: `peruzzo2014variational`. In this algorithm the same circuit is repeated
+:cite:`peruzzo2014variational`. In this algorithm the same circuit is repeated
 many times using different sets of free parameters to minimize an expectation 
 value. The following is an example, in which there is also more than one input
 variable:

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -19,14 +19,14 @@ and return select output parameters.
 
 The ``input`` modifier can be used to indicate that one or more variable
 declarations represent values which will be provided at run-time, upon
-invocation. This allows the programmer touse the same compiled circuits
+invocation. This allows the programmer to use the same compiled circuits
 which only differ in the values of certain parameters. For backward compatibility,
 OpenQASM3 does not require an ``input`` declaration to be provided. When
 an ``input`` declaration is provided, the compiler produces an executable
 that leaves these free parameters unspecified: a circuit run would take as
 input both the executable and some choice of the parameters.
 
-The ``output`` modifier can be used to indicate that one or more variables
+Similarly, the ``output`` modifier can be used to indicate that one or more variables
 are to be provided as an explicit output of the quantum procedure. Note that
 OpenQASM 2 did not allow the programmer to specify that only a subset of its
 variables should be returned as output, and so it would return all classical

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -9,5 +9,95 @@ system or simulator. Ideally the meaning of the program does not change
 if some or all of the directives are ignored, so they can be interpreted
 at the discretion of the consuming process.
 
-input/output
+Input/output
 ============
+
+OpenQASM introduces features targeted to support near-time computation, in
+the form of parameterized circuits. These features are modifiers ``input``
+and ``output``, which allow OpenQASM3 circuits to accept input parameters
+and return select output parameters.
+
+The ``input`` modifier can be used to indicate that one or more variable
+declarations represent values which will be provided at run-time, upon
+invocation. This allows the programmer touse the same compiled circuits
+which only differ in the values of certain parameters. For backward compatibility,
+OpenQASM3 does not require an ``input`` declaration to be provided. When
+an ``input`` declaration is provided, the compiler produces an executable
+that leaves these free parameters unspecified: a circuit run would take as
+input both the executable and some choice of the parameters.
+
+The ``output`` modifier can be used to indicate that one or more variables
+are to be provided as an explicit output of the quantum procedure. Note that
+OpenQASM 2 did not allow the programmer to specify that only a subset of its
+variables should be returned as output, and so it would return all classical
+variables (which were all creg variables) as output. For compatibility, 
+OpenQASM 3 does not require an output declaration to be provided: in this 
+case it assumes that all of the declared variables are to be returned as
+output. If the programmer provides one or more output declarations, then only
+those variables described as outputs will be returned as an output of the 
+quantum process. A variable may not be marked as both input and output.
+
+The input and output modifiers allow the programmer to more easily write 
+variational quantum algorithms: a quantum algorithm with some free parameters,
+which may be run many times with different parameter values which are determined
+by a classical optimiser at near-time. Rather than write a circuit which
+generates a new sequence of operations for each run, OpenQASM 3 allows such
+circuits to be expressed as a single program with input parameters. This 
+allows the programmer to communicate many different circuits with a single
+file, which only has to be compiled once, amortizing the cost of compilation
+across many runs. For an example, we may consider a parameterized circuit which
+performs a measurement in a basis given by an input parameter:
+
+
+.. code-block:: c
+
+    input int basis; // 0 = X basis, 1 = Y basis, 2 = Z basis
+    output bit result;
+    qubit q;
+
+    // Some complicated circuit...
+
+    if (basis == 0) h q;
+    else if (basis == 1) rx(π/2) q;
+    result = measure q;
+
+For a second example, consider the Variable Quantum Eigensolver (VQE) algorithm 
+:cite: `peruzzo2014variational`. In this algorithm the same circuit is repeated
+many times using different sets of free parameters to minimize an expectation 
+value. The following is an example, in which there is also more than one input
+variable:
+
+.. code-block:: c
+
+    input angle param1;
+    input angle param2;
+    qubit q;
+
+    // Build an ansatz using the above free parameters, eg.
+    rx(param1) q;
+    ry(param2) q;
+
+    // Estimate the expectation value and store in an output variable
+
+The following Python pseudocode illustrates the differences between using and
+not using parameterized circuits in a quantum program for the case of the VQE:
+
+.. code-block:: c
+
+    # Example without using parametric circuits:
+    for theta in thetas:
+    # Create an OpenQASM circuit with θ defined
+    circuit = subsitute_theta(read("circuit.qasm"))
+    # The slow compilation step is run on each iteration of the inner loop
+    binary = compile_qasm(circuit)
+    result = run_program(binary)
+    # Example using parametric circuits:
+    # parametric_circuit.qasm begins with the line "input angle θ;"
+    circuit = read("parametric_circuit.qasm")
+    # The slow compilation step only happens once
+    binary = compile_qasm(circuit)
+    for theta in thetas:
+    # Each iteration of the inner loop is reduced to only running the circuit
+    result = run_program(binary, θ=theta)
+
+

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -8,3 +8,6 @@ that give additional information to compiler passes and the target
 system or simulator. Ideally the meaning of the program does not change
 if some or all of the directives are ignored, so they can be interpreted
 at the discretion of the consuming process.
+
+input/output
+============


### PR DESCRIPTION
In this PR, we added
* the section that describes input/output in the live specification.
* input/output grammar in qasm3.g4 which is properly tested.