### PR TITLE
Update the definition of angle to be a 0:0:n fixed-point number x2pi

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -172,7 +172,7 @@ vendors may not support manipulating these values at run-time.
 Fixed-point angles
 ~~~~~~~~~~~~~~~~~~
 
-Fixed-point angles are interpreted as 2π times a 0:1:n-1
+Fixed-point angles are interpreted as 2π times a 0:0:n
 fixed-point number. This represents angles in the interval
 :math:`[0,2\pi)` up to an error :math:`\epsilon\leq \pi/2^{n-1}` modulo
 2π. The statement ``angle[size] name;`` declares an n-bit angle. OpenQASM3


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The definition of the `angle` in the current spec says it is interpreted as a 0:1:n-1 bit fixed-point number times 2pi, but in reality it should not have an integer bit, and should be interpreted as a 0:0:n bit fixed-point number times 2pi.

### Details and comments
This PR updates the precision of the interpretation of angle numbers to be a 0:0:n bit fixed-point number times 2pi. The rest of the definition is correct as far as I can tell, including the section about the precision being up to pi/2^(n-1) modulo 2pi, because it is 2*pi/2^n, which is the same as pi/2^(n-1). We should consider if stating the precision as 2*pi/2^n modulo 2pi is clearer though.

