### PR TITLE
restoring source/grammar/tests/outputs/empty_gate.yaml

### DIFF
--- a/source/grammar/tests/outputs/empty_gate.yaml
+++ b/source/grammar/tests/outputs/empty_gate.yaml
@@ -1,0 +1,17 @@
+# indent w/ 2 spaces
+source: |
+  gate g q {};
+reference: |
+  program
+    header
+    globalStatement
+      quantumGateDefinition
+        gate
+        quantumGateSignature
+          quantumGateName
+            g
+          identifierList
+            q
+        quantumBlock
+          {
+          }


### PR DESCRIPTION
One of the tests refers to the file `empty_gate.yaml`:

https://github.com/Qiskit/openqasm/blob/10c8f18ed5ded761ab926d5faede1bf32497ff02/source/grammar/tests/test_grammar.py#L123

However, this file does not exists, resulting in a test fail. i'm not fully sure when that file was removed and why. Adding it back.