### PR TITLE
Update working groups

### DIFF
--- a/WG.md
+++ b/WG.md
@@ -17,6 +17,8 @@ Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson, Matthew Amy
 
 ### Grammar
 
+Note: this working group will begin working in September 2021.
+
 **Objective**: 
 
 Chair: Li Chen  

--- a/WG.md
+++ b/WG.md
@@ -36,7 +36,7 @@ Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, S
  * Is an int equivalent to an array of bits?
 
 Chair: Michael Healy (IBM Quantum)  
-Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah, Yunong Shi
+Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah, Yunong Shi, Jake Lishman
 
 
 

--- a/WG.md
+++ b/WG.md
@@ -10,7 +10,7 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 
 ### Generics and circuit families
 
-**Objective**: ...
+**Objective**: Recommend what range of generics / parameterised circuit family functionality (beyond angle parameters) would be suitable for inclusion in OpenQASM, and what syntax should be used for it.
 
 Chair: Niel de Beaudrap  
 Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson, Matthew Amy

--- a/WG.md
+++ b/WG.md
@@ -12,7 +12,7 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 
 **Objective**: ...
 
-Chair: Niel Beaudrap  
+Chair: Niel de Beaudrap  
 Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson
 
 ### Grammar
@@ -34,7 +34,7 @@ Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, S
  * Is an int equivalent to an array of bits?
 
 Chair: Michael Healy (IBM Quantum)  
-Members: Niels, Hiroshi, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah 
+Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah, Yunong Shi
 
 
 

--- a/WG.md
+++ b/WG.md
@@ -8,12 +8,42 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 
 ## Current Working Groups
 
+### Generics and circuit families
+
+**Objective**: ...
+
+Chair: Niel Beaudrap  
+Members: Colm Ryan, Andrew, Ali, Blake Johnson
+
+### Grammar working group
+
+**Objective**: 
+
+Chair: Li Chen
+Hiroshi, Healy, Luciano, Jeff, Yunong, Steve
+
+### Types and casting
+
+**Objective**: Define type hierarchy and implicit casting rules.  
+**Questions**:
+
+ * Any implicit casts?
+ * What explicit casts are allowed?
+ * Registers vs arrays?
+ * Can you index into integers and get bit value?
+ * Is an int equivalent to an array of bits?
+
+Chair: Michael Healy (IBM Quantum)  
+Members: Niels, Hiroshi, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah 
+
+
+
 ### OpenPulse
 
-Objective: Define a pulse grammar "openpulse" to be used for microcoding of gate instructions with
+**Objective**: Define a pulse grammar "openpulse" to be used for microcoding of gate instructions with
 OpenQASM `defcal`'s.
-Chair: Thomas Alexander (IBM Quantum)
-Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy,
-Prasahnt Sivarajah, Yunong Shi, Steven Heidel, Zachary Schoenfeld
+
+Chair: Thomas Alexander (IBM Quantum)  
+Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy, Prasahnt Sivarajah, Yunong Shi, Steven Heidel, Zachary Schoenfeld
 
 ## Past Working Groups

--- a/WG.md
+++ b/WG.md
@@ -20,7 +20,7 @@ Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson
 **Objective**: 
 
 Chair: Li Chen  
-Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steve Heidel
+Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steven Heidel
 
 ### Types and casting
 

--- a/WG.md
+++ b/WG.md
@@ -13,14 +13,14 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 **Objective**: ...
 
 Chair: Niel Beaudrap  
-Members: Colm Ryan, Andrew, Ali, Blake Johnson
+Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson
 
 ### Grammar working group
 
 **Objective**: 
 
-Chair: Li Chen
-Hiroshi, Healy, Luciano, Jeff, Yunong, Steve
+Chair: Li Chen  
+Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steve Heidel
 
 ### Types and casting
 
@@ -45,5 +45,6 @@ OpenQASM `defcal`'s.
 
 Chair: Thomas Alexander (IBM Quantum)  
 Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy, Prasahnt Sivarajah, Yunong Shi, Steven Heidel, Zachary Schoenfeld
+
 
 ## Past Working Groups

--- a/WG.md
+++ b/WG.md
@@ -15,7 +15,7 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 Chair: Niel Beaudrap  
 Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson
 
-### Grammar working group
+### Grammar
 
 **Objective**: 
 

--- a/WG.md
+++ b/WG.md
@@ -44,7 +44,7 @@ Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bell
 OpenQASM `defcal`'s.
 
 Chair: Thomas Alexander (IBM Quantum)  
-Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy, Prasahnt Sivarajah, Yunong Shi, Steven Heidel, Zachary Schoenfeld
+Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy, Prasahnt Sivarajah, Yunong Shi, Steven Heidel
 
 
 ## Past Working Groups

--- a/WG.md
+++ b/WG.md
@@ -13,7 +13,7 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 **Objective**: ...
 
 Chair: Niel de Beaudrap  
-Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson
+Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson, Matthew Amy
 
 ### Grammar
 


### PR DESCRIPTION
Adding the following groups, as mandated by the TSC
 * Generics and circuit families
 * Grammar
 * Types and casting