### PR TITLE
Made rhs of classical assignment required

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -55,7 +55,7 @@ classicalDeclarationStatement
     ;
 
 classicalAssignment
-    : Identifier designator? ( assignmentOperator expression )?
+    : Identifier designator? assignmentOperator expression
     ;
 
 assignmentStatement : ( classicalAssignment | quantumMeasurementAssignment ) SEMICOLON ;


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

Made rhs of classical assignment required


### Details and comments

Currently, the rhs in classical assignment is optional:

```
classicalAssignment
    : Identifier designator? ( assignmentOperator expression )?
    ;
```

This was determined to be a bug per [slack discussion](https://qiskit.slack.com/archives/G01KL989ADN/p1628117570011800).