### PR TITLE
Add CI tests for grammar via ANTLR parser

### DIFF
--- a/.github/workflows/tests-grammar.yml
+++ b/.github/workflows/tests-grammar.yml
@@ -1,0 +1,32 @@
+name: Tests (Grammar)
+
+on:
+  [push, pull_request]
+
+jobs:
+  tests:
+    name: ANTLR grammar tests
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-python@v2
+        with:
+          python-version: '3.9'
+      - name: Install ANTLR4
+        run: |
+          sudo apt install antlr4
+      - name: Install Python dependencies
+        working-directory: source/grammar
+        run: |
+          set -e
+          python -mpip install --upgrade pip
+          python -mpip install --upgrade -r requirements.txt -r requirements-dev.txt
+      - name: Generate grammar
+        working-directory: source/grammar
+        run: |
+          antlr4 -Dlanguage=Python3 qasm3.g4
+      - name: Run tests
+        working-directory: source/grammar
+        run: |
+          pytest -vv --color=yes tests

--- a/source/grammar/requirements-dev.txt
+++ b/source/grammar/requirements-dev.txt
@@ -1,0 +1,2 @@
+pytest>=6.0
+pyyaml

--- a/source/grammar/requirements.txt
+++ b/source/grammar/requirements.txt
@@ -1,0 +1,1 @@
+antlr4-python3-runtime


### PR DESCRIPTION
### Summary

This adds a CI run which builds the default ANTLR parser, and runs the
tests currently present in the directory, since it's easy to forget them
when making changes.  The pipeline is simple, and so is just run on the
free tier of GitHub Actions for now.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

This is currently just a very simple Action file, which prepares the environment and then runs the tests exactly as written.  I will likely follow up this PR with one separating out the reference parser from the tests of the it (but not changing it in any way, since the TSC are discussing what exactly will become the reference parser), and add some tests that _invalid_ QASM3 fails to parse, and things like this.

Note that the actual tests and reference parser will likely change drastically in the near future - this PR is just about getting CI up and running in the interim.

Fix #250.