### PR TITLE
Remove incrementors from language specification

### DIFF
--- a/examples/msd.qasm
+++ b/examples/msd.qasm
@@ -160,10 +160,10 @@ distill_and_buffer(buffer_size) workspace, buffer;
 h q[0];
 cx q[0], q[1];
 Ty(address) q[0], buffer;
-address++;
+address += 1;
 cx q[0], q[1];
 Ty(address) q[1], buffer;
-address++;
+address += 1;
 
 // In principle each Ty gate can execute as soon as the magic
 // state is available at the address in the buffer register.

--- a/plugins/vim/syntax/openqasm.vim
+++ b/plugins/vim/syntax/openqasm.vim
@@ -218,7 +218,7 @@ execute 'syntax match qasmComparisonOperator #\V\\(' . join(s:comparison_operato
 if s:openqasm_version >= 3
     let s:general_operators = [ '',
         \ '~', ':', '||', '|', '&&', '&', '^', '*', '/', '>>', '<<', '%', '**',
-        \ '++', '+', '--', '-',
+        \ '+', '-',
     \ '', ]
     execute 'syntax match qasmOperator #\V\\('
         \ . join(s:general_operators, '\|')

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -399,17 +399,11 @@ expressionTerminator
     | timingIdentifier
     | LPAREN expression RPAREN
     | expressionTerminator LBRACKET expression RBRACKET
-    | expressionTerminator incrementor
     ;
 /** End expression hierarchy **/
 
 booleanLiteral
     : 'true' | 'false'
-    ;
-
-incrementor
-    : '++'
-    | '--'
     ;
 
 builtInCall

--- a/source/grammar/tests/outputs/branching.yaml
+++ b/source/grammar/tests/outputs/branching.yaml
@@ -1,7 +1,7 @@
 # indent w/ 2 spaces
 source: |
   if (x == a) {
-    for i in [0:2:4] x[i]++;
+    for i in [0:2:4] x[i] += 1;
   }
   else CX x[0], x[1];
 reference: |
@@ -60,19 +60,20 @@ reference: |
                     ]
               programBlock
                 statement
-                  expressionStatement
-                    expression
-                      expressionTerminator
-                        expressionTerminator
+                  assignmentStatement
+                    classicalAssignment
+                      x
+                      designator
+                        [
+                        expression
                           expressionTerminator
-                            x
-                          [
-                          expression
-                            expressionTerminator
-                              i
-                          ]
-                        incrementor
-                          ++
+                            i
+                        ]
+                      assignmentOperator
+                        +=
+                      expression
+                        expressionTerminator
+                          1
                     ;
           }
         else

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -83,9 +83,7 @@ an index set, for example ``i in {0,3}`` returns ``true`` if i equals 0 or 3 and
 Integers
 ~~~~~~~~
 
-Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, integer division [2]_ ``/``,
-modulo ``%``, and power ``**``; the corresponding assignments ``+=``, ``-=``, ``*=``, ``/=``, ``%=`` and 
-``**=``; as well as increment ``++`` and decrement ``--``.
+Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, integer division [2]_ ``/``, modulo ``%``, and power ``**``, as well as the corresponding assignments ``+=``, ``-=``, ``*=``, ``/=``, ``%=``, and ``**=``.
 
 .. code-block:: c
 
@@ -97,7 +95,6 @@ modulo ``%``, and power ``**``; the corresponding assignments ``+=``, ``-=``, ``
    b % a; // 1
    a ** b; // 8
    a += 4; // a == 6
-   a++; // a == 7
 
 Fixed-point numbers and angles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
@@ -125,7 +122,7 @@ OpenQASM evaluates expressions from left to right.
       +----------------------------------------+------------------------------------+
       | Operator                               | Operator Types                     |
       +----------------------------------------+------------------------------------+
-      | ``()``, ``[]``, ``++``, ``(type)(x)``  | Call, index, incrementors, cast    |
+      | ``()``, ``[]``, ``(type)(x)``          | Call, index, cast                  |
       +----------------------------------------+------------------------------------+
       | ``**``                                 | Power                              |
       +----------------------------------------+------------------------------------+
@@ -206,7 +203,7 @@ within the while loop body.
        h q;
        result = measure q;
        if (result) {
-           i++;
+           i += 1;
        }
    }
 
@@ -220,7 +217,7 @@ preceding, ``{ program }`` can also be replaced by a statement without the brace
    int[32] i = 0;
 
    while (i < 10) {
-       i++;
+       i += 1;
        // continue to next loop iteration
        if (i == 2) {
            continue;


### PR DESCRIPTION
### Summary

This removes the increment-and-return operators '++' and '--' from the
reference text and grammar.  The text did not specify whether these
should be pre- or post-incrementors, though only post-incrementors were
allowed by the ANTLR grammar.

The TSC conensus is that while these operators can easily be defined
unambiguously by parsers, in practice they are less readable by humans
than the equivalent `x += 1;` statement, and there is no significant
benefit to having them in OpenQASM 3.


<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

If we want to merge the CI PR (#251), I'll rebase this over it once it's in to show that the new tests pass.

Fix #144.
