### PR TITLE
Make const initialisation required

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -128,7 +128,7 @@ numericType
     ;
 
 constantDeclaration
-    : 'const' Identifier equalsExpression?
+    : 'const' Identifier equalsExpression
     ;
 
 // if multiple variables declared at once, either none are assigned or all are assigned


### PR DESCRIPTION
### Summary

Const values must be compile-time constant, and can't change their
values.  It doesn't make sense to declare a constant with no value.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

This entered in the same commit as the bug fixed in #249.
