### PR TITLE
vim: Add complex types to syntax highlighting

### DIFF
--- a/plugins/vim/syntax/openqasm.vim
+++ b/plugins/vim/syntax/openqasm.vim
@@ -118,7 +118,7 @@ syntax region qasmIndex matchgroup=qasmOperator start=#\v\[# end=#\v\]# transpar
 " statements to be matched correctly, when the test includes a function call.
 syntax region qasmParams start="(" end=")" transparent contained
 syntax region qasmDesignator start=#\v\[# end=#\v\]# transparent contained
-    \ contains=qasmOperator,qasmInteger,qasmReal,qasmIdentifier nextgroup=qasmParams skipwhite skipempty
+    \ contains=qasmType,qasmOperator,qasmInteger,qasmReal,qasmIdentifier nextgroup=qasmParams skipwhite skipempty
 
 " General keywords.
 syntax keyword qasmInclude include
@@ -142,7 +142,7 @@ if s:openqasm_version < 3
     syntax keyword qasmDefine opaque nextgroup=qasmFunction skipwhite skipempty
 else
     syntax keyword qasmInclude defcalgrammar
-    syntax keyword qasmType bit qubit int uint float fixed bool angle duration stretch
+    syntax keyword qasmType bit qubit int uint float fixed bool angle duration stretch complex
         \ nextgroup=qasmDesignator skipwhite skipempty
     syntax keyword qasmIO input output
     syntax keyword qasmBuiltinQuantum durationof box


### PR DESCRIPTION
### Summary

This simply adds extra options into the type-keyword and designator
matching.  This means that there are now more things that would be
invalid QASM 3 programs, but will be syntax highlighted, but it isn't
really the job of the syntax highlighter to perfectly parse a program;
speed is preferable to total accuracy in negative matches.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->


### Details and comments

Built on top of #264 since otherwise it'll have a merge conflict.  Logically, there's no actual conflict, though, it's just that #264 removes a word from a set, and this adds a new one to the same set.
