### PR TITLE
Fix allowed integral types in scalar indices

### DIFF
--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -342,7 +342,7 @@ interpreted as a register of the same type but with a different size.
 The register slice is a reference to the original register. A register
 cannot be indexed by an empty index set.
 
-An index set can be specified by a single integer (singed or unsigned), a
+An index set can be specified by a single integer (signed or unsigned), a
 comma-separated list of unsigned integers ``a,b,c,…``, or a range. A
 range is written as ``a:b`` or ``a:c:b`` where ``a``, ``b``, and ``c`` are integers (signed or unsigned).
 The range corresponds to the set :math:`\{a, a+c, a+2c, \dots, a+mc\}`

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -342,7 +342,7 @@ interpreted as a register of the same type but with a different size.
 The register slice is a reference to the original register. A register
 cannot be indexed by an empty index set.
 
-An index set can be specified by a single unsigned integer, a
+An index set can be specified by a single integer (singed or unsigned), a
 comma-separated list of unsigned integers ``a,b,c,…``, or a range. A
 range is written as ``a:b`` or ``a:c:b`` where ``a``, ``b``, and ``c`` are integers (signed or unsigned).
 The range corresponds to the set :math:`\{a, a+c, a+2c, \dots, a+mc\}`


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

Fixes #242 

### Summary
This is a fix for a minor document issue. Where, as per the issue #242, The text says " An index set can be specified by a single unsigned integer..." in line 345. But when considered in the example, there is no unsigned index used in the "concatenated"  array.

So as per the suggestions given in the comments chain for the bug, I edited the text of the document in line 345 as "An index set can be specified by a single integer (singed or unsigned),".

### Details and comments
This is my first ever contribution to an open source project. Please review. Will practice more to contribute in the code as well. :)

