### PR TITLE
Remove fixed type from openqasm 3

### DIFF
--- a/examples/vqe.qasm
+++ b/examples/vqe.qasm
@@ -19,9 +19,9 @@ extern get_parameter(uint[prec], uint[prec]) -> angle[prec];
 extern get_npaulis() -> uint[prec];
 extern get_pauli(int[prec]) -> bit[2 * n];
 
-// The energy calculation uses fixed point division,
+// The energy calculation uses floating point division,
 // so we do that calculation in an extern function
-extern update_energy(int[prec], uint[prec], fixed[prec,prec]) -> fixed[prec,prec];
+extern update_energy(int[prec], uint[prec], float[prec]) -> float[prec];
 
 gate entangler q { for i in [0:n-2] { cx q[i], q[i+1]; } }
 def xmeasure(qubit q) -> bit { h q; return measure q; }
@@ -71,8 +71,8 @@ def counts_for_term(bit[2*n] spec, qubit[n] q) -> uint[prec] {
 }
 
 // Estimate the expected energy
-def estimate_energy(qubit[n] q) -> fixed[prec,prec] {
-  fixed[prec, prec] energy;
+def estimate_energy(qubit[n] q) -> float[prec] {
+  float[prec] energy;
   uint[prec] npaulis = get_npaulis();
   for t in [0:npaulis-1] {
     bit[2*n] spec = get_pauli(t);
@@ -84,6 +84,6 @@ def estimate_energy(qubit[n] q) -> fixed[prec,prec] {
 }
 
 qubit[n] q;
-fixed[prec, prec] energy;
+float[prec] energy;
 
 energy = estimate_energy(q);

--- a/plugins/vim/syntax/openqasm.vim
+++ b/plugins/vim/syntax/openqasm.vim
@@ -149,7 +149,7 @@ else
     " The current OpenQASM 3 grammar has 'creg' behave like other classical
     " types (i.e. with the designator immediately after the type name), even
     " though this clashes with OpenQASM 2.
-    syntax keyword qasmType bit qubit int uint float fixed bool angle duration stretch creg
+    syntax keyword qasmType bit qubit int uint float bool angle duration stretch creg
         \ nextgroup=qasmDesignator skipwhite skipempty
     syntax keyword qasmIO input output
     syntax keyword qasmBuiltinQuantum durationof box

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -70,10 +70,6 @@ designator
     : LBRACKET expression RBRACKET
     ;
 
-doubleDesignator
-    : LBRACKET expression COMMA expression RBRACKET
-    ;
-
 identifierList
     : ( Identifier COMMA )* Identifier
     ;
@@ -104,10 +100,6 @@ singleDesignatorType
     | 'angle'
     ;
 
-doubleDesignatorType
-    : 'fixed'
-    ;
-
 noDesignatorType
     : 'bool'
     | timingType
@@ -115,7 +107,6 @@ noDesignatorType
 
 classicalType
     : singleDesignatorType designator
-    | doubleDesignatorType doubleDesignator
     | noDesignatorType
     | bitType designator?
     | 'complex' LBRACKET numericType RBRACKET
@@ -124,7 +115,6 @@ classicalType
 // numeric OpenQASM types
 numericType
     : singleDesignatorType designator
-    | doubleDesignatorType doubleDesignator
     ;
 
 constantDeclaration
@@ -135,10 +125,6 @@ constantDeclaration
 // prevents ambiguity w/ qubit arguments in subroutine calls
 singleDesignatorDeclaration
     : singleDesignatorType designator Identifier equalsExpression?
-    ;
-
-doubleDesignatorDeclaration
-    : doubleDesignatorType doubleDesignator Identifier equalsExpression?
     ;
 
 noDesignatorDeclaration
@@ -155,7 +141,6 @@ complexDeclaration
 
 classicalDeclaration
     : singleDesignatorDeclaration
-    | doubleDesignatorDeclaration
     | noDesignatorDeclaration
     | bitDeclaration
     | complexDeclaration
@@ -169,7 +154,6 @@ classicalArgument
     :
     (
         singleDesignatorType designator |
-        doubleDesignatorType doubleDesignator |
         noDesignatorType
     ) Identifier
     | 'creg' Identifier designator?

--- a/source/grammar/tests/invalid/statements/declarations.qasm
+++ b/source/grammar/tests/invalid/statements/declarations.qasm
@@ -1,7 +1,6 @@
 // Not specifying the variable.
 float;
 uint[8];
-fixed[7, 1];
 qreg[4];
 creg[4];
 complex[float[32]];
@@ -13,8 +12,6 @@ uint myvar;
 uint[8, 8] myvar;
 float myvar;
 float[8, 8] myvar;
-fixed myvar;
-fixed[8] myvar;
 angle myvar;
 angle[8, 8] myvar;
 bool[4] myvar;
@@ -51,7 +48,6 @@ myvar int[8];
 int myvar[8];
 uint myvar[8];
 float myvar[32];
-fixed myvar[7, 1];
 
 // Compound assignments.
 int[8] myvar1, myvar2;

--- a/source/grammar/tests/reference/declaration/complex.yaml
+++ b/source/grammar/tests/reference/declaration/complex.yaml
@@ -2,7 +2,6 @@
 source: |
   complex[int[32]] a;
   complex[float[40]] b = 4-5.5im;
-  complex[fixed[5,7]] c = b+7.5*1e9im;
   complex[angle[20]] d = a + b;
 reference: |
   program
@@ -63,54 +62,6 @@ reference: |
                                   powerExpression
                                     expressionTerminator
                                       5.5im
-        ;
-    statement
-      classicalDeclarationStatement
-        classicalDeclaration
-          complexDeclaration
-            complex
-            [
-            numericType
-              doubleDesignatorType
-                fixed
-              doubleDesignator
-                [
-                expression
-                  expressionTerminator
-                    5
-                ,
-                expression
-                  expressionTerminator
-                    7
-                ]
-            ]
-            c
-            equalsExpression
-              =
-              expression
-                logicalAndExpression
-                  bitOrExpression
-                    xOrExpression
-                      bitAndExpression
-                        equalityExpression
-                          comparisonExpression
-                            bitShiftExpression
-                              additiveExpression
-                                additiveExpression
-                                  multiplicativeExpression
-                                    powerExpression
-                                      expressionTerminator
-                                        b
-                                +
-                                multiplicativeExpression
-                                  multiplicativeExpression
-                                    powerExpression
-                                      expressionTerminator
-                                        7.5
-                                  *
-                                  powerExpression
-                                    expressionTerminator
-                                      1e9im
         ;
     statement
       classicalDeclarationStatement

--- a/source/grammar/tests/reference/subroutine/extern.yaml
+++ b/source/grammar/tests/reference/subroutine/extern.yaml
@@ -1,6 +1,6 @@
 # indent w/ 2 spaces
 source: |
-  extern test_kern(bit[5], uint[10], fixed[4, 5], complex[float[64]]) -> float[6];
+  extern test_kern(bit[5], uint[10], float[16], complex[float[64]]) -> float[6];
 reference: |
   program
     header
@@ -31,17 +31,13 @@ reference: |
               ]
           ,
           classicalType
-            doubleDesignatorType
-              fixed
-            doubleDesignator
+            singleDesignatorType
+              float
+            designator
               [
               expression
                 expressionTerminator
-                  4
-              ,
-              expression
-                expressionTerminator
-                  5
+                  16
               ]
           ,
           classicalType

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -59,7 +59,7 @@ right circular shift, ``rotl`` and ``rotr``, respectively.
 Comparison (Boolean) Instructions
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Integers, fixed-point numbers, angles, bits, and classical registers can
+Integers, angles, bits, and classical registers can
 be compared (:math:`>`, :math:`>=`, :math:`<`, :math:`<=`, :math:`==`,
 :math:`!=`) and yield Boolean values. Boolean values support logical
 operators: and ``&&``, or ``||``, not ``!``. The keyword ``in`` tests if an integer belongs to
@@ -69,7 +69,6 @@ an index set, for example ``i in {0,3}`` returns ``true`` if i equals 0 or 3 and
 
    bool a = false;
    int[32] b = 1;
-   fixed[8, 12] c = 1.05;
    angle[32] d = pi;
    float[32] e = pi;
 
@@ -96,10 +95,10 @@ Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, i
    a ** b; // 8
    a += 4; // a == 6
 
-Fixed-point numbers, floating-point numbers and angles
+Floating-point numbers and angles
 ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
-Fixed-point, floating-point, and angle types support addition, subtraction,
+Floating-point and angle types support addition, subtraction,
 multiplication, division, and power and the corresponding assignment operators.
 
 .. code-block:: c

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -96,7 +96,7 @@ Integer types support addition ``+``, subtraction ``-``, multiplication ``*``, i
    a += 4; // a == 6
 
 Floating-point numbers and angles
-~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
 
 Floating-point and angle types support addition, subtraction,
 multiplication, division, and power and the corresponding assignment operators.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -148,20 +148,6 @@ one another.
    int[16] my_int;
    my_int = int[16](my_uint);
 
-Signed fixed-point numbers
-~~~~~~~~~~~~~~~~~~~~~~~~~~
-
-There are ``1:m:f`` fixed-point numbers with ``m`` integer bits, ``f`` fractional bits, and 1
-sign bit. The statement ``fixed[m, f] name;`` declares a ``1:m:f`` fixed-point number.
-
-.. code-block:: c
-
-   // Declare a 32-bit fixed point number.
-   // The number is signed, has 7 integer bits
-   // and 24 fractional bits. The decimal number
-   // assignment is implicitly cast.
-   fixed[7, 24] my_fixed = -7.0625;
-
 Floating point numbers
 ~~~~~~~~~~~~~~~~~~~~~~
 
@@ -201,7 +187,7 @@ Complex numbers
 ~~~~~~~~~~~~~~~
 
 Complex numbers may be declared as ``complex[type[size]] name``, for a numeric OpenQASM classical type
-``type`` (``int``, ``fixed``, ``float``, ``angle``) and a number of bits ``size``. The real
+``type`` (``int``, ``float``, ``angle``) and a number of bits ``size``. The real
 and imaginary parts of the complex number are ``type[size]`` types. For instance, ``complex[float[32]] c``
 would declare a complex number with real and imaginary parts that are 32-bit floating point numbers. The
 ``im`` keyword defines the imaginary number :math:`sqrt(-1)`. ``complex[type[size]]`` types are initalized as


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
The Types and Casting Work Group ran into many problems when trying to define specific casting rules related to the fixed-point type and conversions to other types. We then stepped back and considered whether the fixed-point type `fixed` was even really necessary. We have yet to find an example of a significant problem that it solves that cannot be worked around with other language features.

### Details and comments

This PR removes the `fixed` type from the specification, grammar, tests, and examples.