### PR TITLE
Support For *Composition* Inverses 

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -409,7 +409,18 @@ builtInCall
     ;
 
 builtInMath
-    : 'sin' | 'cos' | 'tan' | 'exp' | 'ln' | 'sqrt' | 'rotl' | 'rotr' | 'popcount'
+    : 'sin'
+    | 'asin'
+    | 'cos'
+    | 'acos'
+    | 'tan'
+    | 'atan'
+    | 'exp'
+    | 'ln'
+    | 'sqrt'
+    | 'rotl'
+    | 'rotr'
+    | 'popcount'
     ;
 
 castOperator


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary
Added grammar support for built-in math functions:
-     asin
-     acos
-     atan

### Details and comments
Per issue: [124](https://github.com/Qiskit/openqasm/issues/124)
Files modified:   source/grammar/qasm3.g4
Lines Modified:   411-423