### PR TITLE
allow no designator for singleDesignatorType

### DIFF
--- a/source/grammar/qasm3Parser.g4
+++ b/source/grammar/qasm3Parser.g4
@@ -48,14 +48,14 @@ quantumDeclaration: QREG Identifier designator? | QUBIT designator? Identifier;
 quantumArgument: QREG Identifier designator? | QUBIT designator? Identifier;
 
 /** Classical Types **/
-bitType: BIT | CREG;
-singleDesignatorType: INT | UINT | FLOAT | ANGLE;
+bitType: (BIT | CREG) designator?;
+singleDesignatorType: (INT | UINT | FLOAT | ANGLE) designator?;
 noDesignatorType: BOOL | DURATION | STRETCH;
 
 nonArrayType
-    : singleDesignatorType designator
+    : singleDesignatorType
     | noDesignatorType
-    | bitType designator?
+    | bitType
     | COMPLEX LBRACKET numericType RBRACKET
 ;
 
@@ -72,13 +72,13 @@ classicalType
 ;
 
 // numeric OpenQASM types
-numericType: singleDesignatorType designator;
+numericType: singleDesignatorType;
 
 constantDeclaration: CONST classicalType Identifier equalsExpression;
 
 // if multiple variables declared at once, either none are assigned or all are assigned
 // prevents ambiguity w/ qubit arguments in subroutine calls
-singleDesignatorDeclaration: singleDesignatorType designator Identifier equalsExpression?;
+singleDesignatorDeclaration: singleDesignatorType Identifier equalsExpression?;
 
 noDesignatorDeclaration: noDesignatorType Identifier equalsExpression?;
 
@@ -102,7 +102,7 @@ classicalDeclaration
 
 classicalTypeList: classicalType (COMMA classicalType)*;
 classicalArgument
-    : (singleDesignatorType designator | noDesignatorType) Identifier
+    : (singleDesignatorType | noDesignatorType) Identifier
     | CREG Identifier designator?
     | BIT designator? Identifier
     | COMPLEX LBRACKET numericType RBRACKET Identifier

--- a/source/grammar/tests/invalid/statements/const.qasm
+++ b/source/grammar/tests/invalid/statements/const.qasm
@@ -1,7 +1,6 @@
 const myvar;
 const myvar = ;
 const myvar = 8.0;
-const int myvar = 8;
 input const myvar = 8;
 output const myvar = 8;
 const input myvar = 8;

--- a/source/grammar/tests/invalid/statements/declarations.qasm
+++ b/source/grammar/tests/invalid/statements/declarations.qasm
@@ -6,13 +6,9 @@ creg[4];
 complex[float[32]];
 
 // Incorrect designators.
-int myvar;
 int[8, 8] myvar;
-uint myvar;
 uint[8, 8] myvar;
-float myvar;
 float[8, 8] myvar;
-angle myvar;
 angle[8, 8] myvar;
 bool[4] myvar;
 bool[4, 4] myvar;
@@ -22,7 +18,6 @@ creg[2, 2] myvar;
 qreg[2] myvar;
 qreg[2, 2] myvar;
 complex myvar;
-complex[float] myvar;
 complex[32] myvar;
 complex[mytype] myvar;
 complex[float[32], float[32]] myvar;

--- a/source/grammar/tests/reference/assignment/assignment.yaml
+++ b/source/grammar/tests/reference/assignment/assignment.yaml
@@ -56,12 +56,12 @@ reference: |
           singleDesignatorDeclaration
             singleDesignatorType
               int
-            designator
-              [
-              expression
-                expressionTerminator
-                  10
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    10
+                ]
             x
             equalsExpression
               =
@@ -111,12 +111,12 @@ reference: |
                     nonArrayType
                       singleDesignatorType
                         int
-                      designator
-                        [
-                        expression
-                          expressionTerminator
-                            10
-                        ]
+                        designator
+                          [
+                          expression
+                            expressionTerminator
+                              10
+                          ]
                 (
                 expressionList
                   expression

--- a/source/grammar/tests/reference/assignment/slices.yaml
+++ b/source/grammar/tests/reference/assignment/slices.yaml
@@ -24,12 +24,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      16
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        16
+                    ]
               ,
               expressionList
                 expression
@@ -77,12 +77,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      16
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        16
+                    ]
               ,
               expressionList
                 expression

--- a/source/grammar/tests/reference/declaration/array.yaml
+++ b/source/grammar/tests/reference/declaration/array.yaml
@@ -28,12 +28,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      16
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        16
+                    ]
               ,
               expressionList
                 expression
@@ -52,12 +52,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   int
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      8
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        8
+                    ]
               ,
               expressionList
                 expression
@@ -76,12 +76,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   float
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      64
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        64
+                    ]
               ,
               expressionList
                 expression
@@ -104,12 +104,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   angle
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      32
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        32
+                    ]
               ,
               expressionList
                 expression
@@ -136,12 +136,12 @@ reference: |
               nonArrayType
                 bitType
                   bit
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      8
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        8
+                    ]
               ,
               expressionList
                 expression
@@ -160,12 +160,12 @@ reference: |
               nonArrayType
                 bitType
                   creg
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      16
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        16
+                    ]
               ,
               expressionList
                 expression
@@ -191,12 +191,12 @@ reference: |
                 numericType
                   singleDesignatorType
                     float
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        32
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          32
+                      ]
                 ]
               ,
               expressionList
@@ -234,12 +234,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   int
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      8
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        8
+                    ]
               ,
               expressionList
                 expression
@@ -277,12 +277,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   int
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      8
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        8
+                    ]
               ,
               expressionList
                 expression
@@ -305,12 +305,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   int
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      8
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        8
+                    ]
               ,
               expressionList
                 expression
@@ -360,12 +360,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      32
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        32
+                    ]
               ,
               expressionList
                 expression
@@ -452,12 +452,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      32
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        32
+                    ]
               ,
               expressionList
                 expression
@@ -537,12 +537,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      32
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        32
+                    ]
               ,
               expressionList
                 expression
@@ -602,12 +602,12 @@ reference: |
               nonArrayType
                 singleDesignatorType
                   uint
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      32
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        32
+                    ]
               ,
               expressionList
                 expression

--- a/source/grammar/tests/reference/declaration/complex.yaml
+++ b/source/grammar/tests/reference/declaration/complex.yaml
@@ -16,12 +16,12 @@ reference: |
             numericType
               singleDesignatorType
                 int
-              designator
-                [
-                expression
-                  expressionTerminator
-                    32
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      32
+                  ]
             ]
             a
         ;
@@ -34,12 +34,12 @@ reference: |
             numericType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    40
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      40
+                  ]
             ]
             b
             equalsExpression
@@ -77,12 +77,12 @@ reference: |
             numericType
               singleDesignatorType
                 angle
-              designator
-                [
-                expression
-                  expressionTerminator
-                    20
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      20
+                  ]
             ]
             d
             equalsExpression
@@ -120,12 +120,12 @@ reference: |
             numericType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    32
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      32
+                  ]
             ]
             c
             equalsExpression

--- a/source/grammar/tests/reference/declaration/declaration.yaml
+++ b/source/grammar/tests/reference/declaration/declaration.yaml
@@ -2,6 +2,7 @@
 source: |
   int[10] x;
   int[10] y;
+  uint x;
   qubit[6] q1;
   qubit q2;
   bit[4] b1="0100";
@@ -23,12 +24,12 @@ reference: |
           singleDesignatorDeclaration
             singleDesignatorType
               int
-            designator
-              [
-              expression
-                expressionTerminator
-                  10
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    10
+                ]
             x
         ;
     statement
@@ -37,13 +38,21 @@ reference: |
           singleDesignatorDeclaration
             singleDesignatorType
               int
-            designator
-              [
-              expression
-                expressionTerminator
-                  10
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    10
+                ]
             y
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          singleDesignatorDeclaration
+            singleDesignatorType
+              uint
+            x
         ;
     globalStatement
       quantumDeclarationStatement
@@ -151,12 +160,12 @@ reference: |
             nonArrayType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    64
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      64
+                  ]
           c
           equalsExpression
             =
@@ -172,12 +181,12 @@ reference: |
             nonArrayType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    64
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      64
+                  ]
           d
           equalsExpression
             =

--- a/source/grammar/tests/reference/expression/built_in_call.yaml
+++ b/source/grammar/tests/reference/expression/built_in_call.yaml
@@ -29,12 +29,12 @@ reference: |
                   nonArrayType
                     singleDesignatorType
                       int
-                    designator
-                      [
-                      expression
-                        expressionTerminator
-                          32
-                      ]
+                      designator
+                        [
+                        expression
+                          expressionTerminator
+                            32
+                        ]
               (
               expressionList
                 expression

--- a/source/grammar/tests/reference/expression/order_of_ops.yaml
+++ b/source/grammar/tests/reference/expression/order_of_ops.yaml
@@ -130,12 +130,12 @@ reference: |
                             nonArrayType
                               bitType
                                 bit
-                              designator
-                                [
-                                expression
-                                  expressionTerminator
-                                    8
-                                ]
+                                designator
+                                  [
+                                  expression
+                                    expressionTerminator
+                                      8
+                                  ]
                         (
                         expressionList
                           expression

--- a/source/grammar/tests/reference/expression/sub_and_extern_call.yaml
+++ b/source/grammar/tests/reference/expression/sub_and_extern_call.yaml
@@ -52,12 +52,12 @@ reference: |
           singleDesignatorDeclaration
             singleDesignatorType
               int
-            designator
-              [
-              expression
-                expressionTerminator
-                  2
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    2
+                ]
             y
             equalsExpression
               =

--- a/source/grammar/tests/reference/header.yaml
+++ b/source/grammar/tests/reference/header.yaml
@@ -23,12 +23,12 @@ reference: |
           nonArrayType
             singleDesignatorType
               angle
-            designator
-              [
-              expression
-                expressionTerminator
-                  32
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    32
+                ]
         param1
         ;
       io
@@ -38,12 +38,12 @@ reference: |
           nonArrayType
             singleDesignatorType
               angle
-            designator
-              [
-              expression
-                expressionTerminator
-                  32
-              ]
+              designator
+                [
+                expression
+                  expressionTerminator
+                    32
+                ]
         param2
         ;
       io

--- a/source/grammar/tests/reference/subroutine/array.yaml
+++ b/source/grammar/tests/reference/subroutine/array.yaml
@@ -23,12 +23,12 @@ reference: |
                 nonArrayType
                   singleDesignatorType
                     uint
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        16
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          16
+                      ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
                   expressionList
@@ -60,12 +60,12 @@ reference: |
                 nonArrayType
                   singleDesignatorType
                     uint
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        16
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          16
+                      ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
                   expressionList
@@ -97,12 +97,12 @@ reference: |
                 nonArrayType
                   singleDesignatorType
                     uint
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        16
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          16
+                      ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
                   #dim
@@ -131,12 +131,12 @@ reference: |
                 nonArrayType
                   singleDesignatorType
                     uint
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        16
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          16
+                      ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
                   #dim
@@ -184,12 +184,12 @@ reference: |
                 nonArrayType
                   singleDesignatorType
                     int
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        8
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          8
+                      ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
                   #dim
@@ -212,12 +212,12 @@ reference: |
                   numericType
                     singleDesignatorType
                       float
-                    designator
-                      [
-                      expression
-                        expressionTerminator
-                          64
-                      ]
+                      designator
+                        [
+                        expression
+                          expressionTerminator
+                            64
+                        ]
                   ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
@@ -241,12 +241,12 @@ reference: |
                   numericType
                     singleDesignatorType
                       float
-                    designator
-                      [
-                      expression
-                        expressionTerminator
-                          64
-                      ]
+                      designator
+                        [
+                        expression
+                          expressionTerminator
+                            64
+                        ]
                   ]
                 ,
                 arrayReferenceTypeDimensionSpecifier
@@ -267,12 +267,12 @@ reference: |
             nonArrayType
               singleDesignatorType
                 int
-              designator
-                [
-                expression
-                  expressionTerminator
-                    8
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      8
+                  ]
         subroutineBlock
           {
           }

--- a/source/grammar/tests/reference/subroutine/extern.yaml
+++ b/source/grammar/tests/reference/subroutine/extern.yaml
@@ -14,34 +14,34 @@ reference: |
             nonArrayType
               bitType
                 bit
-              designator
-                [
-                expression
-                  expressionTerminator
-                    5
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      5
+                  ]
           ,
           classicalType
             nonArrayType
               singleDesignatorType
                 uint
-              designator
-                [
-                expression
-                  expressionTerminator
-                    10
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      10
+                  ]
           ,
           classicalType
             nonArrayType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    16
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      16
+                  ]
           ,
           classicalType
             nonArrayType
@@ -50,12 +50,12 @@ reference: |
               numericType
                 singleDesignatorType
                   float
-                designator
-                  [
-                  expression
-                    expressionTerminator
-                      64
-                  ]
+                  designator
+                    [
+                    expression
+                      expressionTerminator
+                        64
+                    ]
               ]
         )
         returnSignature
@@ -64,10 +64,10 @@ reference: |
             nonArrayType
               singleDesignatorType
                 float
-              designator
-                [
-                expression
-                  expressionTerminator
-                    6
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      6
+                  ]
         ;

--- a/source/grammar/tests/reference/subroutine/subroutine.yaml
+++ b/source/grammar/tests/reference/subroutine/subroutine.yaml
@@ -23,12 +23,12 @@ reference: |
             classicalArgument
               singleDesignatorType
                 int
-              designator
-                [
-                expression
-                  expressionTerminator
-                    5
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      5
+                  ]
               i
           ,
           anyTypeArgument
@@ -59,12 +59,12 @@ reference: |
             nonArrayType
               singleDesignatorType
                 int
-              designator
-                [
-                expression
-                  expressionTerminator
-                    10
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      10
+                  ]
         subroutineBlock
           {
           statement
@@ -73,12 +73,12 @@ reference: |
                 singleDesignatorDeclaration
                   singleDesignatorType
                     int
-                  designator
-                    [
-                    expression
-                      expressionTerminator
-                        10
-                    ]
+                    designator
+                      [
+                      expression
+                        expressionTerminator
+                          10
+                      ]
                   result
               ;
           statement
@@ -157,12 +157,12 @@ reference: |
             classicalArgument
               singleDesignatorType
                 int
-              designator
-                [
-                expression
-                  expressionTerminator
-                    5
-                ]
+                designator
+                  [
+                  expression
+                    expressionTerminator
+                      5
+                  ]
               i
           ,
           anyTypeArgument

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -131,8 +131,12 @@ Integers
 
 There are n-bit signed and unsigned integers. The statements ``int[size] name;`` and ``uint[size] name;`` declare
 signed 1:n-1:0 and unsigned 0:n:0 integers of the given size. The sizes
-are always explicitly part of the type; there is no implicit width for
-classical types in OpenQASM. Because register indices are integers, they
+and the surrounding brackets can be omitted (*e.g.* ``int name;``) to use
+a precision that is specified by the particular target architecture.
+Bit-level operations cannot be used on types without a specified width, and
+unspecified-width types are different to *all* specified-width types for
+the purposes of casting.
+Because register indices are integers, they
 can be cast from classical registers containing measurement outcomes and
 may only be known at run time. An n-bit classical register containing
 bits can also be reinterpreted as an integer, and these types can be
@@ -148,6 +152,8 @@ one another.
    // Declare a 16 bit signed integer
    int[16] my_int;
    my_int = int[16](my_uint);
+   // Declare a machine-sized integer
+   int my_machine_int;
 
 Floating point numbers
 ~~~~~~~~~~~~~~~~~~~~~~
@@ -156,11 +162,18 @@ IEEE 754 floating point registers may be declared with ``float[size] name;``, wh
 indicate a standard double-precision float. Note that some hardware
 vendors may not support manipulating these values at run-time.
 
+Similar to integers, floating-point registers can be declared with an
+unspecified size.  The resulting precision is then set by the particular target
+architecture, and the unspecified-width type is different to all specified-width
+types for the purposes of casting.
+
 .. code-block:: c
    :force:
 
    // Declare a single-precision 32-bit float
    float[32] my_float = π;
+   // Declare a machine-precision float.
+   float my_machine_float = 2.3;
 
 Fixed-point angles
 ~~~~~~~~~~~~~~~~~~
@@ -168,8 +181,12 @@ Fixed-point angles
 Fixed-point angles are interpreted as 2π times a 0:0:n
 fixed-point number. This represents angles in the interval
 :math:`[0,2\pi)` up to an error :math:`\epsilon\leq \pi/2^{n-1}` modulo
-2π. The statement ``angle[size] name;`` declares an n-bit angle. OpenQASM3
-introduces this specialized type because of the ubiquity of this angle
+2π. The statement ``angle[size] name;`` declares an n-bit angle, and
+``angle name;`` declares an angle with machine-architecture-specified width.
+In cases where the width is not specified, bit-level operations are forbidden,
+and the type is different from all other sized angle types for the purposes of
+casting, similar to the rules for integers.
+OpenQASM3 introduces this specialized type because of the ubiquity of this angle
 representation in phase estimation circuits and numerically controlled
 oscillators found in hardware platform. Note that defining gate
 parameters with ``angle`` types may be necessary for those parameters to be
@@ -183,12 +200,14 @@ compatible with run-time values on some platforms.
    float[32] float_pi = π;
    // equivalent to pi_by_2 up to rounding errors
    angle[20](float_pi / 2);
+   // Declare a machine-sized angle
+   angle my_machine_angle;
 
 Complex numbers
 ~~~~~~~~~~~~~~~
 
-Complex numbers may be declared as ``complex[type[size]] name``, for a numeric OpenQASM classical type
-``type`` (``int``, ``float``, ``angle``) and a number of bits ``size``. The real
+Complex numbers may be declared as ``complex[type] name``, for a numeric OpenQASM classical type
+``type`` (``int``, ``float``, ``angle`` plus their optional size). The real
 and imaginary parts of the complex number are ``type[size]`` types. For instance, ``complex[float[32]] c``
 would declare a complex number with real and imaginary parts that are 32-bit floating point numbers. The
 ``im`` keyword defines the imaginary number :math:`sqrt(-1)`. ``complex[type[size]]`` types are initalized as
@@ -201,6 +220,7 @@ left of ``im`` and the two can only be seperated by spaces/tabs (or nothing at a
    c = 2.5 + 3.5im; // 2.5, 3.5 are resolved to be ``float[64]`` types
    complex[float[64]] d = 2.0+sin(π) + 3.1*5.5 im;
    complex[int[32]] f = 2 + 5 im; // 2, 5 are resolved to be ``int[32]`` types
+   complex[float] my_machine_complex;
 
 Boolean types
 ~~~~~~~~~~~~~

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -129,9 +129,51 @@ def test_qubit_and_bit_declaration():
     SpanGuard().visit(program)
 
 
+def test_simple_type_declarations():
+    p = """
+    int[32] a;
+    int[const_expr] a;
+    int a;
+    uint[32] a = 1;
+    uint[const_expr] a;
+    uint a = 1;
+    float[32] a;
+    float a;
+    angle[32] a;
+    angle a;
+    """.strip()
+    program = parse(p)
+    a = Identifier("a")
+    one = IntegerLiteral(1)
+    thirty_two = IntegerLiteral(32)
+    const_expr = Identifier("const_expr")
+    assert program == Program(
+        statements=[
+            ClassicalDeclaration(type=IntType(size=thirty_two), identifier=a, init_expression=None),
+            ClassicalDeclaration(type=IntType(size=const_expr), identifier=a, init_expression=None),
+            ClassicalDeclaration(type=IntType(size=None), identifier=a, init_expression=None),
+            ClassicalDeclaration(type=UintType(size=thirty_two), identifier=a, init_expression=one),
+            ClassicalDeclaration(
+                type=UintType(size=const_expr), identifier=a, init_expression=None
+            ),
+            ClassicalDeclaration(type=UintType(size=None), identifier=a, init_expression=one),
+            ClassicalDeclaration(
+                type=FloatType(size=thirty_two), identifier=a, init_expression=None
+            ),
+            ClassicalDeclaration(type=FloatType(size=None), identifier=a, init_expression=None),
+            ClassicalDeclaration(
+                type=AngleType(size=thirty_two), identifier=a, init_expression=None
+            ),
+            ClassicalDeclaration(type=AngleType(size=None), identifier=a, init_expression=None),
+        ],
+    )
+    SpanGuard().visit(program)
+
+
 def test_complex_declaration():
     p = """
     complex[int[24]] iq;
+    complex[float] fq;
     """.strip()
     program = parse(p)
     assert program == Program(
@@ -139,6 +181,11 @@ def test_complex_declaration():
             ClassicalDeclaration(
                 ComplexType(base_type=IntType(IntegerLiteral(24))),
                 Identifier("iq"),
+                None,
+            ),
+            ClassicalDeclaration(
+                ComplexType(base_type=FloatType(size=None)),
+                Identifier("fq"),
                 None,
             ),
         ]
@@ -151,6 +198,7 @@ def test_complex_declaration():
 def test_array_declaration():
     p = """
     array[uint[8], 2] a;
+    array[uint, 2] a;
     array[int[8], 2] a = {1, 1};
     array[bit, 2] a = b;
     array[float[32], 2, 2] a;
@@ -165,6 +213,11 @@ def test_array_declaration():
         statements=[
             ClassicalDeclaration(
                 type=ArrayType(base_type=UintType(eight), dimensions=[two]),
+                identifier=a,
+                init_expression=None,
+            ),
+            ClassicalDeclaration(
+                type=ArrayType(base_type=UintType(size=None), dimensions=[two]),
                 identifier=a,
                 init_expression=None,
             ),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`int`, `uint`, and `float` allow no designator.

### Details and comments

The paper allows `int`, `uint`, and `float` variable declaration without width:
```
int x = 5;
```

This PR will resolve a part of issues written in https://github.com/Qiskit/openqasm/issues/210.