### PR TITLE
`rangeDefinition` has at least two expressions

### DIFF
--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -192,7 +192,7 @@ indexIdentifierList
     ;
 
 rangeDefinition
-    : LBRACKET expression? COLON expression? ( COLON expression )? RBRACKET
+    : LBRACKET expression COLON expression ( COLON expression )? RBRACKET
     ;
 
 /*** Gates and Built-in Quantum Instructions ***/


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Summary

`rangeDefinition` must have at least two expressions

### Details and comments

`rangeDefinition` is defined in the [spec](https://qiskit.github.io/openqasm/language/types.html#register-concatenation-and-slicing):

> A range is written as `a:b` or `a:c:b` where `a`, `b`, and `c` are integers (signed or unsigned). The range corresponds to the set `{a, a+c, a+2c, ..., a+mc  }` where is the largest integer such that `a + mc <= b` if `c>0` and `a + mc >=b` if `c < 0`. If `a == b` then the range corresponds to `{a}`. Otherwise, the range is the empty set. If `c` is not given, it is assumed to be one, and `c` cannot be zero. Note the index sets can be defined by variables whose values may only be known at run time.

According to the above definition, the `rangeDefinition` has at least two expressions `a` and `b`. The current Antlr grammar allows no expression, such as `[:]`.