### PR TITLE
OpenPulse WG deactivated. Grammar WG removed.

### DIFF
--- a/WG.md
+++ b/WG.md
@@ -23,7 +23,7 @@ Note: this working group will begin working in September 2021.
 **Questions**:
 
  * Are their pain points in the grammar?
- * Are their places we can improve?
+ * Are there places we can improve?
  * Can we improve the performance?
  * Can we improve the style?
 

--- a/WG.md
+++ b/WG.md
@@ -15,21 +15,6 @@ for review by the TSC at an agreed upon date. A WG will be automatically disband
 Chair: Niel de Beaudrap  
 Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson, Matthew Amy
 
-### Grammar
-
-Note: this working group will begin working in September 2021.
-
-**Objective**: Improve ANTLR reference implementation of OpenQASM grammar
-**Questions**:
-
- * Are their pain points in the grammar?
- * Are there places we can improve?
- * Can we improve the performance?
- * Can we improve the style?
-
-Chair: Li Chen  
-Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steven Heidel, Jake Lishman
-
 ### Types and casting
 
 **Objective**: Define type hierarchy and implicit casting rules.  
@@ -45,6 +30,7 @@ Chair: Michael Healy (IBM Quantum)
 Members: Niel de Beaudrap, Hiroshi Horii, Blake Johnson, Colm Ryan, Luciano Bello, Prasahnt Sivarajah, Yunong Shi, Jake Lishman
 
 
+## Past Working Groups
 
 ### OpenPulse
 
@@ -53,6 +39,3 @@ OpenQASM `defcal`'s.
 
 Chair: Thomas Alexander (IBM Quantum)  
 Members: Blake Johnson, Colm Ryan, Derek Bolt, Peter Karalekas, Lauren Capelluto, Michael Healy, Prasahnt Sivarajah, Yunong Shi, Steven Heidel
-
-
-## Past Working Groups

--- a/WG.md
+++ b/WG.md
@@ -19,7 +19,13 @@ Members: Colm Ryan, Andrew Cross, Ali Javadi, Blake Johnson, Matthew Amy
 
 Note: this working group will begin working in September 2021.
 
-**Objective**: 
+**Objective**: Improve ANTLR reference implementation of OpenQASM grammar
+**Questions**:
+
+ * Are their pain points in the grammar?
+ * Are their places we can improve?
+ * Can we improve the performance?
+ * Can we improve the style?
 
 Chair: Li Chen  
 Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steven Heidel

--- a/WG.md
+++ b/WG.md
@@ -28,7 +28,7 @@ Note: this working group will begin working in September 2021.
  * Can we improve the style?
 
 Chair: Li Chen  
-Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steven Heidel
+Members: Hiroshi Horii, Michael Healy, Luciano Bello, Jeff Heckey, Yunong Shi, Steven Heidel, Jake Lishman
 
 ### Types and casting
 


### PR DESCRIPTION
### Summary

During the September 17th 2021 TSC meeting, it was agreed that:
 * the Grammar WG should be removed
 * the OpenPulse WG reached its goals and should be deactivated.


