### PR TITLE
Correct spec examples of subroutine definitions

### DIFF
--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -1,32 +1,30 @@
 Subroutines
 ===========
 
-Subroutines are declared using the statement ``def name(parameters) qargs -> output { body }``.
+Subroutines are declared using the statement ``def name(parameters) -> output_type { body }``.
 Zero or more quantum bits
-and registers are passed to the subroutine by reference or name in ``qargs``.
-Classical types are passed by value in ``parameters``. The parentheses may be omitted if no
-``parameters`` are passed. The subroutines return up to one value of classical type, signified by the
+and classical values are passed to the subroutine by reference or name in ``qargs``.
+Classical types are passed by value in ``parameters``.
+The subroutines return up to one value of classical type, signified by the
 ``return`` keyword. If there is no return type, the empty ``return``
 keyword may be used to immediately exit from the subroutine. All arguments are declared together
 with their type, for example ``qubit ancilla`` would define a quantum bit argument named ``ancilla``.
 Qubit declarations are not allowed within subroutines as they are global. A subroutine
-is invoked with the syntax ``name(parameters) qargs`` and may be assigned to an ``output`` as
-needed via an assignment operator (``=``, ``+=``, etc). ``parameters`` and ``qargs`` are literals
-and ``output`` is a variable.
+is invoked with the syntax ``name(parameters)`` and may be assigned to an ``output`` as
+needed via an assignment operator (``=``, ``+=``, etc).
 
 Using subroutines, we can define an X-basis measurement with the program
-``def xmeasure qubit q -> bit { h q; return measure q; }``.
+``def xmeasure(qubit q) -> bit { h q; return measure q; }``.
 We can also define more general classes of single-qubit measurements
 as
-``def pmeasure(angle[32] theta) qubit q -> bit { rz(theta) q; h q; return
-measure q; }``.
+``def pmeasure(angle[32] theta, qubit q) -> bit { rz(theta) q; h q; return measure q; }``.
 The type declarations are necessary if we want to mix qubit and
 register arguments. For example, we might define a parity check
 subroutine that takes qubits and registers
 
 .. code-block:: c
 
-   def xcheck qubit[4] d, qubit a -> bit {
+   def xcheck(qubit[4] d, qubit a) -> bit {
      reset a;
      for i in [0: 3] cx d[i], a;
      return measure a;


### PR DESCRIPTION
### Summary

The specification still had the old form of subroutine definitions
listed, where qubit arguments were specified separately to the classical
ones.  This was outdated by commit cc9bbc7, and this commit brings the
spec in line with both the grammar and the paper.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.
-->

### Details and comments

Judging by Steven's comment in #217 (https://github.com/Qiskit/openqasm/pull/217#issuecomment-852476827), this change happened last-minute as the paper went out the door, and that's presumably how the discrepancy arose.

Related to #284.
