### PR TITLE
Added power operator for `complex` type

### DIFF
--- a/source/grammar/tests/reference/declaration/complex.yaml
+++ b/source/grammar/tests/reference/declaration/complex.yaml
@@ -119,7 +119,7 @@ reference: |
                     32
                 ]
             ]
-            b
+            c
             equalsExpression
               =
               expression
@@ -131,11 +131,10 @@ reference: |
                           comparisonExpression
                             bitShiftExpression
                               additiveExpression
-                                additiveExpression
-                                  multiplicativeExpression
-                                    powerExpression
-                                      expressionTerminator
-                                        a
+                                multiplicativeExpression
+                                  powerExpression
+                                    expressionTerminator
+                                      a
                                     **
                                     powerExpression
                                       expressionTerminator

--- a/source/grammar/tests/reference/declaration/complex.yaml
+++ b/source/grammar/tests/reference/declaration/complex.yaml
@@ -3,6 +3,7 @@ source: |
   complex[int[32]] a;
   complex[float[40]] b = 4-5.5im;
   complex[angle[20]] d = a + b;
+  complex[float[32]] c = a ** b;
 reference: |
   program
     header
@@ -101,4 +102,42 @@ reference: |
                                   powerExpression
                                     expressionTerminator
                                       b
+        ;
+    statement
+      classicalDeclarationStatement
+        classicalDeclaration
+          complexDeclaration
+            complex
+            [
+            numericType
+              singleDesignatorType
+                float
+              designator
+                [
+                expression
+                  expressionTerminator
+                    32
+                ]
+            ]
+            b
+            equalsExpression
+              =
+              expression
+                logicalAndExpression
+                  bitOrExpression
+                    xOrExpression
+                      bitAndExpression
+                        equalityExpression
+                          comparisonExpression
+                            bitShiftExpression
+                              additiveExpression
+                                additiveExpression
+                                  multiplicativeExpression
+                                    powerExpression
+                                      expressionTerminator
+                                        a
+                                    **
+                                    powerExpression
+                                      expressionTerminator
+                                        b
         ;

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -122,8 +122,9 @@ assignment operators.
    complex[float[64]] b = -2.0 - 7.0im;
    complex[float[64]] c = a + b; // c = 8.0 - 2.0im
    complex[float[64]] d = a - b; // d = 12.0+12.0im;
-   complex[float[64]] e = a*b; // e = 15.0-80.0im;
-   complex[float[64]] f = a/b; // f = (-55.0+60.0im)/53.0
+   complex[float[64]] e = a * b; // e = 15.0-80.0im;
+   complex[float[64]] f = a / b; // f = (-55.0+60.0im)/53.0
+   complex[float[64]] g = a ** b; // g = (0.10694695640729072+0.17536481119721312im)
 
 Evaluation order
 ~~~~~~~~~~~~~~~~

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -113,7 +113,7 @@ multiplication, division, and power and the corresponding assignment operators.
 Complex numbers
 ~~~~~~~~~~~~~~~
 
-Complex numbers support addition, subtraction, multiplication, and division and the corresponding
+Complex numbers support addition, subtraction, multiplication, division, power and the corresponding
 assignment operators.
 
 .. code-block:: c


### PR DESCRIPTION
### Summary
Added scope for having power operator: `**`, for `complex` types in the language specification.


### Details and comments
Had a short discussion with @mbhealy and @jwoehr, and concluded that the cost of allowing the power operator is trivial, and added it for the sake of completeness of operations on the `complex` type.