### PR TITLE
Swap concatenation operator to ++ from ||

### DIFF
--- a/plugins/vim/syntax/openqasm.vim
+++ b/plugins/vim/syntax/openqasm.vim
@@ -214,7 +214,7 @@ execute 'syntax match qasmComparisonOperator #\V\\(' . join(s:comparison_operato
 if s:openqasm_version >= 3
     let s:general_operators = [ '',
         \ '~', ':', '||', '|', '&&', '&', '^', '*', '/', '>>', '<<', '%', '**',
-        \ '+', '-',
+        \ '+', '-', '++',
     \ '', ]
     execute 'syntax match qasmOperator #\V\\('
         \ . join(s:general_operators, '\|')

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -184,7 +184,7 @@ aliasStatement
 indexIdentifier
     : Identifier rangeDefinition
     | Identifier ( LBRACKET expressionList RBRACKET )?
-    | indexIdentifier '||' indexIdentifier
+    | indexIdentifier '++' indexIdentifier
     ;
 
 indexIdentifierList

--- a/source/grammar/tests/reference/assignment/alias.yaml
+++ b/source/grammar/tests/reference/assignment/alias.yaml
@@ -4,10 +4,10 @@ source: |
   creg b[2];
   qubit[5] q1;
   qreg q2[7];
-  let q = q1 || q2;
-  let c = a[0,1] || b[1:2];
+  let q = q1 ++ q2;
+  let c = a[0,1] ++ b[1:2];
   let qq = q1[1,3,4];
-  let qqq = qq || q2[1:2:6];
+  let qqq = qq ++ q2[1:2:6];
   let d = c;
   let e = d[1];
 reference: |
@@ -71,7 +71,7 @@ reference: |
         indexIdentifier
           indexIdentifier
             q1
-          ||
+          ++
           indexIdentifier
             q2
         ;
@@ -93,7 +93,7 @@ reference: |
                 expressionTerminator
                   1
             ]
-          ||
+          ++
           indexIdentifier
             b
             rangeDefinition
@@ -137,7 +137,7 @@ reference: |
         indexIdentifier
           indexIdentifier
             qq
-          ||
+          ++
           indexIdentifier
             q2
             rangeDefinition

--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -55,7 +55,7 @@ follows
    c = measure q;
    c2 = measure r;
    bit result;
-   result = parity(c || c2);
+   result = parity(c ++ c2);
 
 We require that we know the signature at compile time, as we do in this
 example. We could also just as easily have used an extern function for
@@ -70,4 +70,4 @@ this
    c = measure q;
    c2 = measure r;
    bit result;
-   result = parity(c || c2);
+   result = parity(c ++ c2);

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -317,7 +317,7 @@ Two or more registers of the same type (i.e. classical or quantum) can
 be concatenated to form a register of the same type whose size is the
 sum of the sizes of the individual registers. The concatenated register
 is a reference to the bits or qubits of the original registers. The
-statement ``a || b`` denotes the concatenation of registers ``a`` and ``b``. A register cannot
+statement ``a ++ b`` denotes the concatenation of registers ``a`` and ``b``. A register cannot
 be concatenated with any part of itself.
 
 Classical and quantum registers can be indexed in a way that selects a
@@ -342,7 +342,7 @@ variables whose values may only be known at run time.
    qubit[2] one;
    qubit[10] two;
    // Aliased register of twelve qubits
-   let concatenated = one || two;
+   let concatenated = one ++ two;
    // First qubit in aliased qubit array
    let first = concatenated[0];
    // Last qubit in aliased qubit array
@@ -356,4 +356,4 @@ variables whose values may only be known at run time.
    // Using negative ranges to take the last 3 elements
    let last_three = two[-4:-1];
    // Concatenate two alias in another one
-   let both = sliced || last_three;
+   let both = sliced ++ last_three;

--- a/source/openqasm/ast.py
+++ b/source/openqasm/ast.py
@@ -683,7 +683,7 @@ class IndexIdentifier(QASMNode):
         b
         b[1]
         b[3:5]
-        b || c
+        b ++ c
     """
 
 
@@ -759,8 +759,8 @@ class Concatenation(IndexIdentifier):
 
     Example::
 
-        segment1 || segment2
-        qubits[0:10] || qubits[15:20]
+        segment1 ++ segment2
+        qubits[0:10] ++ qubits[15:20]
     """
 
     lhs: Union[IndexIdentifier, Identifier]

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -730,7 +730,7 @@ def test_slice():
 
 def test_concatenation():
     p = """
-    let a = b[1:1:10] || c;
+    let a = b[1:1:10] ++ c;
     """.strip()
     program = parse(p)
     assert program == Program(


### PR DESCRIPTION
### Summary

This is the consensus of the TSC from 2021-09-16, in order to avoid a
clash between concatenation and logical or.  This operator is similar to
that used in Haskell and Scala for the same purpose.  Originally,
OpenQASM 3 had the pre- and post-increment operator which would also
have clashed with ++, but this is no longer the case, so the token is
free for clash-free usage.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Further discussion was in #214.  This change is likely going to cause a bit of a nuisance for existing implementations right now, but hopefully concatenation isn't used too heavily in real-world uses of OpenQASM 3 yet.

Apologies for the delay on implementing this TSC decision - I think it fell through the cracks with nobody actually assigned to action it.

Fix #214.