### PR TITLE
Add prose on expected compile-/run-time support

### DIFF
--- a/source/intro.rst
+++ b/source/intro.rst
@@ -48,6 +48,29 @@ For the previous versions of OpenQASM please read arXiv:1707.03429_.
 
 .. _arXiv:1707.03429: https://arxiv.org/abs/1707.03429
 
+Implementation Details
+----------------------
+
+OpenQASM 3 is a large expansion over the previous OpenQASM 2 specification.
+Many new features for classical control flow and computation are added to make writing quantum algorithms easier, and to describe classical data processing that forms part of these algorithms.
+The language, however, is not designed to be used for general-purpose classical computation, and in the near term, any hardware that executes an OpenQASM 3 program is unlikely to support the full set of data manipulations the language can describe.
+
+Hardware implementations of OpenQASM 3 are permitted to restrict their runtime processing to only the set of operations that they can perform efficiently and in real time.
+This set of operations will differ between implementations; you should consult your hardware vendor for which language features you can expect to be possible at runtime.
+Implementations are likely to become more powerful over time, as the requirements for quantum control become less onerous to achieve.
+
+It is expected that *compilers* for OpenQASM 3 will support all of the classical operations specified in this document for values that can be reasonably inferred to be compile-time constants, and will perform these operations at compile time.
+At a minimum, "reasonably inferred" means values declared ``const``, and literals.
+For example, this means that the "scientific-calculator functions" such as ``sin``, ``exp``, and so on will always work on expressions involving only literals and values declared ``const`` of compatible types, and the compiler will completely fold such expressions into a single constant.
+Whether such operations can occur on run-time values is implementation-specific.
+This extends further, even to which types may be declared and used.
+An implementation of OpenQASM 3 is permitted to reject programs that use, for example, ``int[5]`` or ``float[16]`` declarations, if the hardware has no facilities to support them.
+Similarly, even if a hardware implementation accepts values declared ``complex[float[64]]``, it is not required to accept programs that use the infix ``**`` power operator on them at runtime, but a compiler is required to evaluate such operator expressions if the operands are compile-time known.
+
+Hardware implementations that support a particular feature *must* follow the rules for it given in this specification, unless such a feature is specifically stated to be "implementation-defined".
+If they cannot, then they *must not* accept programs that use that feature.
+The user can therefore expect that if an OpenQASM 3 program accepted by two implementations, both will perform the same behaviour except in cases this document explicitly allows it to differ.
+
 
 Contributors
 ------------


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

This is a first draft of text describing the requirements of compilers and hardware implementations of OpenQASM 3.  The intent is to make it clear that a hardware implementation does not need to support every feature described in this specification to call itself an "OpenQASM 3 implementation", and that we strongly expect that no hardware implementation in the near future will accept _every_ operation described in the document at runtime.

I'm happy to completely redraft this if we want to go about it a different way.


### Details and comments

This fulfills an action item from the TSC meeting on 2021-10-29.

There are various things I particularly think might be worth discussion:
- should we define what constitutes a "compiler" and a "hardware implementation" in the text?  I'm mostly thinking that a near-time scheduler may blur the lines a little here.
- should we produce a complete list of all operations that _may_ be forbidden at runtime, rather than my paragraph with a few examples?  Or perhaps we should commit to notating every feature in the document as "required/not required at runtime"?
- did I match the TSC's opinion on the philosophy of the language in the first paragraph?  I generally tried to pull it from the preprint white paper, but I wasn't part of writing that, so I may have misinterpreted it.