### PR TITLE
Fix #313. Solves some symbol clashes in the spec.

### DIFF
--- a/examples/dd.qasm
+++ b/examples/dd.qasm
@@ -5,10 +5,10 @@
 OPENQASM 3.0;
 include "stdgates.inc";
 
-stretch s;
-duration start_stretch = -0.5 * durationof({x $0;}) + s;
-duration middle_stretch = -0.5 * durationof({x $0;}) - 5 * durationof({y $0;}) + s;
-duration end_stretch = -0.5 * durationof({y $0;}) + s;
+stretch a;
+duration start_stretch = -0.5 * durationof({x $0;}) + a;
+duration middle_stretch = -0.5 * durationof({x $0;}) - 5 * durationof({y $0;}) + a;
+duration end_stretch = -0.5 * durationof({y $0;}) + a;
 
 box {
   delay[start_stretch] $0;

--- a/examples/pong.qasm
+++ b/examples/pong.qasm
@@ -36,14 +36,14 @@ duration maxdur = 1us;
 qubit[2] q;
 barrier q[0], q[1];
 slowgate q[0];
-stretch s;
-delay[s] q[1];
+stretch a;
+delay[a] q[1];
 h q[1];
 measure q[1] -> c[0];
-delay[s] q[1];
+delay[a] q[1];
 box [maxdur] { // fixed-duration anonymous subroutine
     if (c==0) U(0.1, 0.2, 0.3) q[1];  // duration depends on result of measurement
-    delay[s] q[1];                 // glue to allow to stretch (can be implicit)
+    delay[a] q[1];                 // glue to allow to stretch (can be implicit)
 } // throw runtime error if `box` does not conclude by maxdur
-delay[s] q[1];
+delay[a] q[1];
 barrier q[0], q[1];

--- a/examples/stdgates.inc
+++ b/examples/stdgates.inc
@@ -33,7 +33,7 @@ gate ry(θ) a { U(θ, 0, 0) a; }
 gate rz(λ) a { gphase(-λ/2); U(0, 0, λ) a; }
 
 // controlled-NOT
-gate cx c, t { ctrl @ x c, t; }
+gate cx a, b { ctrl @ x a, b; }
 // controlled-Y
 gate cy a, b { ctrl @ y a, b; }
 // controlled-Z
@@ -58,11 +58,11 @@ gate ccx a, b, c { ctrl @ ctrl @ x a, b, c; }
 gate cswap a, b, c { ctrl @ swap a, b, c; }
 
 // four parameter controlled-U gate with relative phase γ
-gate cu(θ, φ, λ, γ) c, t { p(γ) c; ctrl @ U(θ, φ, λ) c, t; }
+gate cu(θ, φ, λ, γ) a, b { p(γ) a; ctrl @ U(θ, φ, λ) a, b; }
 
 // Gates for OpenQASM 2 backwards compatibility
 // CNOT
-gate CX c, t { ctrl @ U(π, 0, π) c, t; }
+gate CX a, b { ctrl @ U(π, 0, π) a, v; }
 // phase gate
 gate phase(λ) q { U(0, 0, λ) q; }
 // controlled-phase

--- a/examples/stdgates.inc
+++ b/examples/stdgates.inc
@@ -62,7 +62,7 @@ gate cu(θ, φ, λ, γ) a, b { p(γ) a; ctrl @ U(θ, φ, λ) a, b; }
 
 // Gates for OpenQASM 2 backwards compatibility
 // CNOT
-gate CX a, b { ctrl @ U(π, 0, π) a, v; }
+gate CX a, b { ctrl @ U(π, 0, π) a, b; }
 // phase gate
 gate phase(λ) q { U(0, 0, λ) q; }
 // controlled-phase

--- a/source/language/delays.rst
+++ b/source/language/delays.rst
@@ -89,12 +89,12 @@ whatever their actual durations may be, we can do the following:
        cx q[0], q[1];
        U(pi/4, 0, pi/2) q[2];
        cx q[3], q[4];
-       stretch s;
-       stretch t;
-       stretch u;
-       delay[s] q[0], q[1];
-       delay[t] q[2];
-       delay[u] q[3], q[4];
+       stretch a;
+       stretch b;
+       stretch c;
+       delay[a] q[0], q[1];
+       delay[b] q[2];
+       delay[c] q[3], q[4];
        barrier q;
 
 We can further control the exact alignment by giving relative weights to
@@ -244,11 +244,11 @@ to properly take into account the finite duration of each gate.
 
 .. code-block:: c
 
-   stretch s;
-   stretch t;
-   duration start_stretch = s - .5 * durationof({x $0;});
-   duration middle_stretch = s - .5 * duration0({x $0;}) - .5 * durationof({y $0;});
-   duration end_stretch = s - .5 * durationof({y $0;});
+   stretch a;
+   stretch b;
+   duration start_stretch = a - .5 * durationof({x $0;});
+   duration middle_stretch = a - .5 * duration0({x $0;}) - .5 * durationof({y $0;});
+   duration end_stretch = a - .5 * durationof({y $0;});
 
    delay[start_stretch] $0;
    x $0;
@@ -261,7 +261,7 @@ to properly take into account the finite duration of each gate.
    delay[end_stretch] $0;
 
    cx $2, $3;
-   delay[t] $1;
+   delay[b] $1;
    cx $1, $2;
    u $3;
 
@@ -340,14 +340,14 @@ in the following example
 
    cx r[0], r[1];
    h q[0];
-   h s[0];
+   h a[0];
    barrier r, q[0];
-   h s[0];
+   h a[0];
    cx r[1], r[0];
    cx r[0], r[1];
 
 This will prevent an attempt to combine the CNOT gates but will not
-constrain the pair of ``h s[0];`` gates, which might be executed before or after the
+constrain the pair of ``h a[0];`` gates, which might be executed before or after the
 barrier, or cancelled by a compiler.
 
 A ``barrier`` is similar to ``delay[0]``. The main difference is that ``delay`` indicates a fully

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -60,8 +60,8 @@ the NOT gate is given by ``X = U(π, 0, π)`` and the block
 .. code-block:: c
    :force:
 
-   gate CX c, t {
-      ctrl @ U(π, 0, π) c, t;
+   gate CX a, b {
+      ctrl @ U(π, 0, π) a, b;
    }
 
    CX q[1], q[0];

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -33,8 +33,8 @@ and to declare a set of classical variables
 
 .. code-block:: c
 
-   int[32] x;
-   float[32] y = 5.5;
+   int[32] a;
+   float[32] b = 5.5;
    bit[3] c;
    bool my_bool = false;
 


### PR DESCRIPTION

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary
Many places in the specification use variables/parameters/arguments
names that would inevitably clash with names used in gates declarations
in the standard gate library (`stdgates.inc`). This PR tries to solves most 
(but unlikely all) of them.

### Details and comments
Someone more familiar with the `openpulse` part of the specification
needs to go through it to fix potential problems. (I not that familiar with it.)

The discussion in #313 raises points that are likely to span other issues
and deserve more discussion.

