### PR TITLE
add type field to constant declaration in ast

### DIFF
--- a/source/openqasm/ast.py
+++ b/source/openqasm/ast.py
@@ -554,9 +554,10 @@ class ConstantDeclaration(Statement):
 
     Example::
 
-        const n = 10;
+        const int[16] n = 10;
     """
 
+    type: ClassicalType
     identifier: Identifier
     init_expression: Expression
 

--- a/source/openqasm/parser/antlr/qasm_parser.py
+++ b/source/openqasm/parser/antlr/qasm_parser.py
@@ -403,6 +403,7 @@ class QASMNodeVisitor(qasm3Visitor):
     @span
     def visitConstantDeclaration(self, ctx: qasm3Parser.ConstantDeclarationContext):
         return ConstantDeclaration(
+            type=self.visit(ctx.classicalType()),
             identifier=add_span(
                 Identifier(name=ctx.Identifier().getText()), get_span(ctx.Identifier())
             ),


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Add `type` field to `ConstantDeclaration` in `ast.py` to reflect the official grammar. Modify `visitConstantDeclaration` in `qasm_parser.py` to add the type field from the context.


### Details and comments

Bug fix, no open issue found. Tests pass after change.
