### PR TITLE
Require braces in discrete-set indexing

### DIFF
--- a/examples/varteleport.qasm
+++ b/examples/varteleport.qasm
@@ -27,7 +27,7 @@ rz(pi / 4) input_qubit;
 
 let io = input_qubit;
 for i in [0: n_pairs - 1] {
-  let bp = q[2 * i, 2 * i + 1];
+  let bp = q[{2*i, 2*i + 1}];
   bit[2] pf;
   bellprep bp;
   cx io, bp[0];

--- a/plugins/vim/syntax/openqasm.vim
+++ b/plugins/vim/syntax/openqasm.vim
@@ -112,7 +112,8 @@ syntax match qasmFunction #\v\K\k*\ze\s*(\(|\s\K)# contained nextgroup=qasmParam
 
 syntax match qasmIdentifier #\v<\K\k*>#
 
-syntax region qasmIndex matchgroup=qasmOperator start=#\v\[# end=#\v\]# transparent
+syntax region qasmIndexSet matchgroup=qasmOperator start=#\v\{# end=#\v\}# transparent contained
+syntax region qasmIndex matchgroup=qasmOperator start=#\v\[# end=#\v\]# transparent contains=qasmIndexSet
 
 " This parameters syntax item is necessary to allow "if" and "while" single-line
 " statements to be matched correctly, when the test includes a function call.

--- a/source/grammar/qasm3.g4
+++ b/source/grammar/qasm3.g4
@@ -183,7 +183,7 @@ aliasStatement
 
 indexIdentifier
     : Identifier rangeDefinition
-    | Identifier ( LBRACKET expressionList RBRACKET )?
+    | Identifier (LBRACKET (discreteSet | expression) RBRACKET)?
     | indexIdentifier '++' indexIdentifier
     ;
 
@@ -440,8 +440,10 @@ assignmentOperator
     | '+=' | '-=' | '*=' | '/=' | '&=' | '|=' | '~=' | '^=' | '<<=' | '>>=' | '%=' | '**='
     ;
 
+discreteSet: LBRACE expressionList RBRACE;
+
 setDeclaration
-    : LBRACE expressionList RBRACE
+    : discreteSet
     | rangeDefinition
     | Identifier
     ;

--- a/source/grammar/tests/invalid/statements/declarations.qasm
+++ b/source/grammar/tests/invalid/statements/declarations.qasm
@@ -53,3 +53,9 @@ float myvar[32];
 int[8] myvar1, myvar2;
 int[8] myvari, float[32] myvarf;
 int[8] myvari float[32] myvarf;
+
+// Aliasing.
+// Index sets should have explicit `{}` inside the `[]`.  However, this line may
+// be _grammatically_ valid when multidimensional arrays are added, in which
+// case this test needs removing.
+let qq = my_var[1, 2, 3];

--- a/source/grammar/tests/reference/assignment/alias.yaml
+++ b/source/grammar/tests/reference/assignment/alias.yaml
@@ -5,8 +5,8 @@ source: |
   qubit[5] q1;
   qreg q2[7];
   let q = q1 ++ q2;
-  let c = a[0,1] ++ b[1:2];
-  let qq = q1[1,3,4];
+  let c = a[{0,1}] ++ b[1:2];
+  let qq = q1[{1,3,4}];
   let qqq = qq ++ q2[1:2:6];
   let d = c;
   let e = d[1];
@@ -84,14 +84,17 @@ reference: |
           indexIdentifier
             a
             [
-            expressionList
-              expression
-                expressionTerminator
-                  0
-              ,
-              expression
-                expressionTerminator
-                  1
+            discreteSet
+              {
+              expressionList
+                expression
+                  expressionTerminator
+                    0
+                ,
+                expression
+                  expressionTerminator
+                    1
+              }
             ]
           ++
           indexIdentifier
@@ -115,18 +118,21 @@ reference: |
         indexIdentifier
           q1
           [
-          expressionList
-            expression
-              expressionTerminator
-                1
-            ,
-            expression
-              expressionTerminator
-                3
-            ,
-            expression
-              expressionTerminator
-                4
+          discreteSet
+            {
+            expressionList
+              expression
+                expressionTerminator
+                  1
+              ,
+              expression
+                expressionTerminator
+                  3
+              ,
+              expression
+                expressionTerminator
+                  4
+            }
           ]
         ;
     statement
@@ -171,9 +177,8 @@ reference: |
         indexIdentifier
           d
           [
-          expressionList
-            expression
-              expressionTerminator
-                1
+          expression
+            expressionTerminator
+              1
           ]
         ;

--- a/source/grammar/tests/reference/assignment/assignment.yaml
+++ b/source/grammar/tests/reference/assignment/assignment.yaml
@@ -131,19 +131,17 @@ reference: |
             indexIdentifier
               q
               [
-              expressionList
-                expression
-                  expressionTerminator
-                    1
+              expression
+                expressionTerminator
+                  1
               ]
           ->
           indexIdentifier
             a
             [
-            expressionList
-              expression
-                expressionTerminator
-                  0
+            expression
+              expressionTerminator
+                0
             ]
         ;
     statement

--- a/source/grammar/tests/reference/control_flow/branch_binop.yaml
+++ b/source/grammar/tests/reference/control_flow/branch_binop.yaml
@@ -97,10 +97,9 @@ reference: |
                     indexIdentifier
                       q
                       [
-                      expressionList
-                        expression
-                          expressionTerminator
-                            i
+                      expression
+                        expressionTerminator
+                          i
                       ]
               ;
           }

--- a/source/grammar/tests/reference/control_flow/branching.yaml
+++ b/source/grammar/tests/reference/control_flow/branching.yaml
@@ -88,18 +88,16 @@ reference: |
                     indexIdentifier
                       x
                       [
-                      expressionList
-                        expression
-                          expressionTerminator
-                            0
+                      expression
+                        expressionTerminator
+                          0
                       ]
                     ,
                     indexIdentifier
                       x
                       [
-                      expressionList
-                        expression
-                          expressionTerminator
-                            1
+                      expression
+                        expressionTerminator
+                          1
                       ]
               ;

--- a/source/grammar/tests/reference/control_flow/loop.yaml
+++ b/source/grammar/tests/reference/control_flow/loop.yaml
@@ -46,20 +46,21 @@ reference: |
                 j
                 in
                 setDeclaration
-                  {
-                  expressionList
-                    expression
-                      expressionTerminator
-                        1
-                    ,
-                    expression
-                      expressionTerminator
-                        4
-                    ,
-                    expression
-                      expressionTerminator
-                        6
-                  }
+                  discreteSet
+                    {
+                    expressionList
+                      expression
+                        expressionTerminator
+                          1
+                      ,
+                      expression
+                        expressionTerminator
+                          4
+                      ,
+                      expression
+                        expressionTerminator
+                          6
+                    }
               programBlock
                 statement
                   quantumStatement
@@ -70,10 +71,9 @@ reference: |
                           indexIdentifier
                             q
                             [
-                            expressionList
-                              expression
-                                expressionTerminator
-                                  j
+                            expression
+                              expressionTerminator
+                                j
                             ]
                     ;
           statement

--- a/source/grammar/tests/reference/subroutine/subroutine.yaml
+++ b/source/grammar/tests/reference/subroutine/subroutine.yaml
@@ -188,16 +188,17 @@ reference: |
                 j
                 in
                 setDeclaration
-                  {
-                  expressionList
-                    expression
-                      expressionTerminator
-                        2
-                    ,
-                    expression
-                      expressionTerminator
-                        3
-                  }
+                  discreteSet
+                    {
+                    expressionList
+                      expression
+                        expressionTerminator
+                          2
+                      ,
+                      expression
+                        expressionTerminator
+                          3
+                    }
               programBlock
                 statement
                   assignmentStatement

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -329,7 +329,7 @@ The register slice is a reference to the original register. A register
 cannot be indexed by an empty index set.
 
 An index set can be specified by a single integer (signed or unsigned), a
-comma-separated list of unsigned integers ``a,b,c,…``, or a range. A
+comma-separated list of unsigned integers contained in braces ``{a,b,c,…}``, or a range. A
 range is written as ``a:b`` or ``a:c:b`` where ``a``, ``b``, and ``c`` are integers (signed or unsigned).
 The range corresponds to the set :math:`\{a, a+c, a+2c, \dots, a+mc\}`
 where :math:`m` is the largest integer such that :math:`a+mc\leq b` if
@@ -350,7 +350,7 @@ variables whose values may only be known at run time.
    // Last qubit in aliased qubit array
    let last = concatenated[-1];
    // Qubits zero, three and five
-   let qubit_selection = two[0, 3, 5];
+   let qubit_selection = two[{0, 3, 5}];
    // First six qubits in aliased qubit array
    let sliced = concatenated[0:6];
    // Every second qubit

--- a/source/openqasm/parser/antlr/qasm_parser.py
+++ b/source/openqasm/parser/antlr/qasm_parser.py
@@ -323,20 +323,17 @@ class QASMNodeVisitor(qasm3Visitor):
         if ctx.Identifier():
             name = ctx.Identifier().getText()
 
-            if ctx.expressionList():
-                expr_list = []
-                for expr in ctx.expressionList().expression():
-                    expr_list.append(self.visit(expr))
-                if len(expr_list) > 1:
-                    subscript = Selection(name=name, indices=expr_list)
-                else:
-                    subscript = Subscript(name=name, index=expr_list[0])
-
+            if ctx.discreteSet():
+                indices = [
+                    self.visit(expr) for expr in ctx.discreteSet().expressionList().expression()
+                ]
+                subscript = Selection(name=name, indices=indices)
+            elif ctx.expression():
+                subscript = Subscript(name=name, index=self.visit(ctx.expression()))
             elif ctx.rangeDefinition():
                 subscript = Slice(name=name, range=self.visit(ctx.rangeDefinition()))
-
             else:
-                return add_span(Identifier(name=ctx.Identifier().getText()), get_span(ctx))
+                return add_span(Identifier(name=name), get_span(ctx))
 
         else:
             id0 = self.visit(ctx.indexIdentifier()[0])

--- a/source/openqasm/tests/test_qasm_parser.py
+++ b/source/openqasm/tests/test_qasm_parser.py
@@ -669,7 +669,7 @@ def test_subscript():
 
 def test_selection():
     p = """
-    let a = b[1, 2];
+    let a = b[{1, 2}];
     """.strip()
     program = parse(p)
     assert program == Program(
@@ -684,9 +684,9 @@ def test_selection():
     )
     SpanGuard().visit(program)
     selection = program.statements[0]
-    assert selection.span == Span(1, 0, 1, 15)
+    assert selection.span == Span(1, 0, 1, 17)
     assert selection.target.span == Span(1, 4, 1, 4)
-    assert selection.value.span == Span(1, 8, 1, 14)
+    assert selection.value.span == Span(1, 8, 1, 16)
 
 
 def test_slice():


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

This changes the syntax of indexing a discrete set out of a register, by
requiring explicit braces around the list.  For example, what was
previously

    let alias = register[1, 2, 3];

is now

    let alias = register[{1, 2, 3}];

The reason for this change is to avoid a confusing syntax conflict with
multi-dimensional arrays, as they will use the old form to be
multi-dimensional indexing.  While arrays and aliased registers may well
be distinct in the type system, it would still be confusing for
programmers to have the same syntax mean two quite separate things.


### Details and comments

I made this a separate PR rather than folding it into the arrays one (#283) because it can be made as an isolated change, so simpler to review.

The arrays PR will be updated to change from `arr[a][b][c]` syntax to `arr[a, b, c]` syntax for multi-dimensional indexing, which collides with the current index-set indexing of registers.  This is considered an issue for the programmer, rather than the compiler - the type system may help with disambiguation, but having `arr[a, b, c]` have different semantics to `alias[a, b, c]` is confusing for the code reader.

The array multidimensional syntax wants to use `arr[a, b, c]` instead of `arr[a][b][c]` to avoid causing associativity confusion in the programmer; `arr[0:4][0:4]` in the _old_ syntax is a slice across two dimensions, but `(arr[0:4])[0:4]` or `tmp = arr[0:4]; tmp[0:4];` would both only slice the _first_ dimension, as the second slices re-slice the first dimension of the temporary object.  Using the new form also provides a natural separation between "indexes into arrays" and "indexes into the bits inside an object in an array", whereas before there was concern that this would be hard to read.

This was discussed in the TSC meeting on the 17th of December.