### PR TITLE
Use `yaml.safe_load()` for security

### DIFF
--- a/source/grammar/tests/test_grammar.py
+++ b/source/grammar/tests/test_grammar.py
@@ -104,7 +104,7 @@ def cases_from_lines(
 def test_reference_output(filename):
     """Test that the reference files parse to the exact expected output."""
     with open(filename, "r") as file:
-        obj = yaml.load(file, Loader=yaml.FullLoader)
+        obj = yaml.safe_load(file)
     # Make sure the YAML files have only the correct keys.
     assert set(obj) == {"reference", "source"}
     parsed = openqasm_reference_parser.pretty_tree(program=obj["source"])


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Changing `yaml.load(<file>, Loader=yaml.FullLoader)` to `yaml.safe_load(<file>)`
to resolve security finding.

### Details and comments

Using the `yaml.FullLoader` is considered risky from a security perspective
because of the ability to inject code or other malicious payloads into the code
and potentially cause a remote code exploit.

While this code is not used in a web service, and is only in the test code,
there is no current use of complicated object models to require the `FullLoader`
and it doesn't break any of the existing tests to use `safe_load()`. This
prevents false positives from some security scans.

