### PR TITLE
Details for implicit casting and literals

### DIFF
--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -103,12 +103,12 @@ multiplication, division, and power and the corresponding assignment operators.
 
 .. code-block:: c
 
-   angle[20] a = pi / 2;
+   angle[20] a = pi / 2.0;
    angle[20] b = pi;
    a + b; // 3/2 * pi
    a ** b; // 4.1316...
    angle[10] c;
-   c = angle(a + b); // cast to angle[10]
+   c = angle[10](a + b); // cast to angle[10]
 
 Complex numbers
 ~~~~~~~~~~~~~~~

--- a/source/language/classical.rst
+++ b/source/language/classical.rst
@@ -126,6 +126,15 @@ assignment operators.
    complex[float[64]] f = a / b; // f = (-55.0+60.0im)/53.0
    complex[float[64]] g = a ** b; // g = (0.10694695640729072+0.17536481119721312im)
 
+Mixed-type expressions
+~~~~~~~~~~~~~~~~~~~~~~
+
+In general, mixed-type expressions are not allowed. All expression terms must
+have the same type or be explicitly cast to have the same type. Literal types
+must also match. For example, the expression ``3 * pi / 4`` is not legal,
+because it mixes a const float (``pi``) with integer literals, the correct
+expression is ``3.0 * pi / 4.0``.
+
 Evaluation order
 ~~~~~~~~~~~~~~~~
 

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -59,7 +59,7 @@ performs a measurement in a basis given by an input parameter:
    // Some complicated circuit...
 
    if (basis == 0) h q;
-   else if (basis == 1) rx(π/2) q;
+   else if (basis == 1) rx(π/2.0) q;
    result = measure q;
 
 For a second example, consider the Variable Quantum Eigensolver (VQE) algorithm :cite:`peruzzo2014variational`.

--- a/source/language/gates.rst
+++ b/source/language/gates.rst
@@ -37,7 +37,7 @@ values :math:`\theta\in [0,2\pi)`, :math:`\phi\in [0,2\pi)`, and
 :math:`\lambda\in
 [0,2\pi)` in this base gate are angles whose precision is implementation
 dependent [1]_. This specifies any element of :math:`U(2)` up to a
-global phase. For example ``U(π/2, 0, π) q[0];``, applies a Hadamard gate to qubit ``q[0]``.
+global phase. For example ``U(π/2.0, 0.0, π) q[0];``, applies a Hadamard gate to qubit ``q[0]``.
 
 New gates are associated to a unitary transformation by defining them as a sequence of built-in or
 previously defined gates. For example the ``gate`` block
@@ -46,22 +46,22 @@ previously defined gates. For example the ``gate`` block
    :force:
 
    gate h q {
-      U(π/2, 0, π) q;
+      U(π/2.0, 0.0, π) q;
    }
 
 defines a new gate called ``h`` and associates it to the unitary matrix of the Hadamard gate. Once we have
 defined ``h``, we can use it in later ``gate`` blocks. The definition does not imply that ``h`` is
-implemented by an instruction ``U(π/2, 0, π)`` on the quantum computer. The implementation is up to
+implemented by an instruction ``U(π/2.0, 0.0, π)`` on the quantum computer. The implementation is up to
 the user and/or compiler, given information about the instructions supported by a particular target.
 
 Controlled gates can be constructed by adding a control modifier to an existing gate. For example,
-the NOT gate is given by ``X = U(π, 0, π)`` and the block
+the NOT gate is given by ``X = U(π, 0.0, π)`` and the block
 
 .. code-block:: c
    :force:
 
    gate CX a, b {
-      ctrl @ U(π, 0, π) a, b;
+      ctrl @ U(π, 0.0, π) a, b;
    }
 
    CX q[1], q[0];
@@ -140,10 +140,10 @@ of :math:`e^{i\gamma}` to the scope containing the instruction. For example
    :force:
 
    gate rz(tau) q {
-     gphase(-tau/2);
-     U(0, 0, tau) q;
+     gphase(-tau/2.0);
+     U(0.0, 0.0, tau) q;
    }
-   ctrl @ rz(π/2) q[1], q[0];
+   ctrl @ rz(π/2.0) q[1], q[0];
 
 constructs the gate
 
@@ -180,13 +180,13 @@ corresponding OpenQASM code is
 
    gate cphase(θ) a, b
    {
-     U(0, 0, θ / 2) a;
+     U(0.0, 0.0, θ / 2.0) a;
      CX a, b;
-     U(0, 0, -θ / 2) b;
+     U(0.0, 0.0, -θ / 2.0) b;
      CX a, b;
-     U(0, 0, θ / 2) b;
+     U(0.0, 0.0, θ / 2.0) b;
    }
-   cphase(π / 2) q[0], q[1];
+   cphase(π / 2.0) q[0], q[1];
 
 .. _fig_gate:
 .. figure:: ../qpics/gate.svg
@@ -225,12 +225,12 @@ of the gate definition.
    // this is ok:
    gate g a
    {
-     U(0, 0, 0) a;
+     U(0.0, 0.0, 0.0) a;
    }
    // this is invalid:
    gate g a
    {
-     U(0, 0, 0) a[0];
+     U(0.0, 0.0, 0.0) a[0];
    }
 
 Only built-in gate statements, calls to previously defined gates, and

--- a/source/language/pulses.rst
+++ b/source/language/pulses.rst
@@ -70,7 +70,7 @@ physical qubits with different parameter values, e.g.
 .. code-block:: c
 
    defcal rx(pi) $0 { ... }
-   defcal rx(pi / 2) $0 { ... }
+   defcal rx(pi / 2.0) $0 { ... }
 
 Given multiple definitions of the same symbol, the compiler will match
 the most specific definition found for a given operation. Thus, given,
@@ -79,10 +79,10 @@ the most specific definition found for a given operation. Thus, given,
 
 #. ``defcal rx(angle[20] theta) $0  ...``
 
-#. ``defcal rx(pi / 2) $0  ...``
+#. ``defcal rx(pi / 2.0) $0  ...``
 
-the operation ``rx(pi/2) $0`` would match to (3), ``rx(pi) $0`` would
-match (2), ``rx(pi/2) $1`` would match (1).
+the operation ``rx(pi/2.0) $0`` would match to (3), ``rx(pi) $0`` would
+match (2), ``rx(pi/2.0) $1`` would match (1).
 
 Users specify the grammar used inside ``defcal`` blocks with a
 ``defcalgrammar "name"`` declaration. One such grammar is a
@@ -259,7 +259,7 @@ The user would then include the ``backend.inc`` in their own program and use the
 
    // Teach the compiler what the unitary of a Y90p is
    gate Y90p q {
-      rz(-pi/2) q;
+      rz(-pi/2.0) q;
       sx q;
    }
 

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -179,10 +179,10 @@ compatible with run-time values on some platforms.
    :force:
 
    // Declare an angle with 20 bits of precision and assign it a value of π/2
-   angle[20] my_angle = π / 2;
+   angle[20] my_angle = π / 2.0;
    float[32] float_pi = π;
    // equivalent to pi_by_2 up to rounding errors
-   angle[20](float_pi / 2);
+   angle[20](float_pi / 2.0);
 
 Complex numbers
 ~~~~~~~~~~~~~~~
@@ -250,7 +250,7 @@ position and zeros elsewhere.
    // Scientific notation is supported
    const int[64] another_const = 1e12;
    // Constant expressions are supported
-   const float[64] pi_by_2 = π / 2;
+   const float[64] pi_by_2 = π / 2.0;
    // Constants may be cast to real-time values
    float[32] pi_by_2_val = float[32](pi_by_2)
 

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -248,7 +248,7 @@ position and zeros elsewhere.
    // Declare a constant
    const int my_const = 1234;
    // Scientific notation is supported
-   const int[64] another_const = 1e12;
+   const float[64] another_const = 1e12;
    // Constant expressions are supported
    const float[64] pi_by_2 = π / 2.0;
    // Constants may be cast to real-time values
@@ -329,6 +329,66 @@ their argument expression in parentheses:
       | tan      | (``float`` or ``angle``)          | ``float``                            |                                        |
       +----------+-----------------------------------+--------------------------------------+----------------------------------------+
 
+Literals
+--------
+
+There are four types of literals in OpenQASM 3, integer, float, bit string, and
+angle. Literals must be used in expressions and assignments with identifiers
+that have matching types. Mixed-type expressions are not allowed unless the
+operator(s) explicitly accepts different types. Literals used directly in
+assignments (without an expression) will take on the type of the target
+identifier, which may result in compiler warnings if the target type cannot hold
+the given literal value.
+
+Integer literals may be signed, and can be written in decimal, hex, octal, or
+binary, as denoted by a leading ``0x``, ``0o``, or ``0b`` prefix.
+Non-consecutive underscores ``_`` may be inserted between the first and last
+digit of the literal to improve readability for large values.
+
+.. code-block:: c
+
+   int i1 = 1; // decimal
+   int i2 = -1; // neg signed decimal
+   int i3 = +1; // pos signed decimal
+   int i4 = 0xFF; // hex
+   int i5 = 0XBEEF; // uppercase HEX
+   int i6 = 0o73; // octal
+   int i6 = 0b1101; // binary
+   int i8 = 1_000_000 // 1 million with _ for readability
+
+Float literals *must* contain a digit followed by a ``.``, a ``.`` followed by a
+digit, or use scientific notation, and may be given an explicit sign.
+
+.. code-block:: c
+
+   float f1 = 1.0;
+   float f2 = .1; // leading dot
+   float f3 = 0.; // trailing dot
+   float f4 = +2e1; // scientific with + sign
+   float f5 = 2.0E-.1; // uppercase scientific with signed exponent
+
+Bit string literals are denoted by double quotes ``"`` surrounding a number of
+zero and one digits, and may include non-consecutive underscores to improve
+readability for large strings. The sizes of bit string literals should exactly
+match the target bit size.
+
+.. code-block:: c
+
+   bit[8] b1 = "00010001";
+   bit[8] b2 = "0001_0001"; // underscore for readability
+
+Angle literals take the same form as float literals appended by and underscore
+followed by the letter a (``_a``), and should generally be given in the range
+:math:`[0,2\pi)`.
+
+.. code-block:: c
+
+   angle a1 = 1.0_a;
+   angle a2 = .1_a;
+   angle a3 = 0._a;
+   angle a4 = +2e1_a;
+   angle a5 = 2.0E-.1_a;
+
 Arrays
 ------
 
@@ -391,7 +451,7 @@ Duration
 ~~~~~~~~
 
 We introduce a ``duration`` type to express timing.
-Durations are numbers with a unit of time. ``ns, μs, us, ms, and s`` are used for SI time
+Durations are float or integer literals with a unit of time. ``ns, μs, us, ms, and s`` are used for SI time
 units. ``dt`` is a backend-dependent unit equivalent to one waveform sample.
 ``durationof()`` is an intrinsic function used to reference the
 duration of a calibrated gate.

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -235,9 +235,12 @@ calculator-like operations on run-time values require extern function
 calls as described later and are not available by default. Real
 constants can be cast to other types, just like other values.
 
-A standard set of built-in constants which are included in the default
+A standard set of built-in constants that are included in the default
 namespace are listed in table `1 <#tab:real-constants>`__. These constants
 are all of type ``float[64]``.
+Additionally, the constant ``pi_a`` is defined as a machine precision ``angle``
+holding the value ``π``, which is represented by a 1 in the most-significant bit
+position and zeros elsewhere.
 
 .. code-block:: c
    :force:

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -623,6 +623,21 @@ Allowed casts
 
 \*Note: ``duration`` values can be converted to ``float`` using the division operator. See :ref:`divideDuration`
 
+Implicit casting
+~~~~~~~~~~~~~~~~
+
+In general, implicit casting is not supported, given the bit-level specificity
+of the classical types in OpenQASM 3, outside of a few special cases described
+next. All types without a specified size (*i.e.* machine precision types) are
+different from all types with a specified size for casting purposes and must be
+mutally explicitly cast to one another during assignment.
+
+Angle variables may be initialized with floating-point const expressions (*i.e.*
+expressions containing only float literals and const float identifiers) without
+an explicit cast to the angle type. Floating-point const expressions can also be
+used in places where angle-type arguments are expected (*e.g.* in gate and
+subroutine calls).
+
 Casting from bool
 ~~~~~~~~~~~~~~~~~
 

--- a/source/language/types.rst
+++ b/source/language/types.rst
@@ -578,6 +578,21 @@ the slices must match.
    twoD[1:2] = anotherTwoD[0:1]; // allowed
    twoD[1:2, 0] = anotherTwoD[0:1, 1]; // allowed
 
+Array reshaping
+~~~~~~~~~~~~~~~
+
+Multi-dimensional arrays can be cast into a different shape (but with the same
+sub-type) using explicit casting syntax on assignment to another array. The
+effect is similar to C++'s reinterpret_cast. The number of elements of the
+source and target arrays *must* match. Reshaping cannot be done directly in the
+argument to a subroutine or extern, and must go through an intermediate array
+identifier if this behavior is desired.
+
+.. code-block::
+
+   array[int[8], 4, 4] arrA;
+   array[int[8], 16] arrB = array[int[8], 16](arrA);
+
 .. _castingSpecifics:
 
 Casting specifics


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Add details for implicit casting and literals.

### Details and comments

Generally, implicit casting is not allowed, specify the few situations in which implicit casts are allowed (const float expressions to angle on assignment and as arguments to calls).
Also:
- Added pi_a as a reserved keyword for an angle type version of the constant pi
- Specified that mixed-type expressions are disallowed except when a mixed-type operator is specified.
- Described array reshaping (similar to C++ reinterpret cast)

This change would break backwards compatibility with OQ2 because the expression `3*pi/4` interprets the integer literals 3 and 4 as floats. After this PR expressions of that type would have to be of the form `3.0*pi/4.0`. We did not find a good solution to allowing that expression to be implicitly promoted to float without making the rules very complex for when promotion does and does not occur, and we generally dislike the idea of allowing integer to float promotion in general given the bit specificity of the OpenQASM 3 language.