### PR TITLE
Clarify and provide examples for Pragmas and Annotations

### DIFF
--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -1,13 +1,85 @@
 Directives
 ==========
 
-OpenQASM supports a directive mechanism that allows other information to
-be included in the program. A directive begins with ``#pragma`` and
-terminates at the end of the line. Directives can provide annotations
-that give additional information to compiler passes and the target
-system or simulator. Ideally the meaning of the program does not change
+OpenQASM supports directive mechanisms that allows other information to
+be included in the program. Directives are either pragmas or annotations.
+Both are used to supply additional information to the compiler passes and the
+target system or simulator. Ideally the meaning of the program does not change
 if some or all of the directives are ignored, so they can be interpreted
 at the discretion of the consuming process.
+
+Pragmas
+-------
+
+Pragma directives start with ``pragma`` and continue to the end of line. The
+``#pragma`` syntax is also accepted for reverse compatibility. Pragmas should be
+processed as soon as they are encountered; if a pragma is not supported by a
+compiler pass it should be ignored and preserved intact for future passes.
+Ideally, pragmas should be considered global and immutable; avoiding stateful
+interactions is recommended to prevent unexpected behaviors between source
+files.
+
+Pragmas are useful for extending OpenQASM functionality that is not described in
+this specification, such as adding noise operations.
+
+\*Note: The following examples are simply possible implementations, this
+specification does not define any pragmas. Please consult your tool's
+documentation for supported pragmas.
+
+.. code-block:: c
+   :force:
+
+   rx(0.15) q;
+   pragma noise bit_flip(0.1)
+
+Pragmas can also be used to specify system-level information or assertions for
+the entire circuit.
+
+.. code-block:: c
+   :force:
+
+   OPENQASM 3.0;
+
+   // Attach billing information
+   pragma user alice account 12345678
+
+   // Assert that the QPU is healthy to run this circuit
+   pragma max_temp qpu 0.4
+
+   qubit[2] q;
+
+
+Annotations
+-----------
+
+Annotations can be added to supply additional information to the following
+OpenQASM statement. These annotations will apply to the subsequent declaration,
+box, or single line of code. Annotations will start with a ``@`` symbol, have an
+identifying keyword and continue to the end of the line.
+
+\*Note: The following examples are simply possible implementations, this
+specification does not define any annotations. Please consult your tool's
+documentation for supported annotations.
+
+.. code-block:: c
+   :force:
+
+   // Manage port binding on a physical device
+   @bind IOPORT[3:2]
+   input bit[2] control_flags;
+
+   // Instruct compiler to create a reversible version of the function
+   @reversible
+   gate multiply a, b, x {
+      x = a * b;
+   }
+
+   // Prevent swap insertion
+   @noswap
+   box {
+      rx(pi) q[0];
+      cnot q[0], q[1];
+   }
 
 
 Input/output

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -13,15 +13,16 @@ Pragmas
 
 Pragma directives start with ``pragma`` and continue to the end of line. The
 text after ``pragma`` is a single string, and parsing is left to the specific
-implementation. The ``#pragma`` syntax is deprecated, but is accepted for
-compatibility. Pragmas should be processed as soon as they are encountered; if a
+implementation. Implementations may optionally choose to support the older ``#pragma``
+keyword as a custom extension.
+Pragmas should be processed as soon as they are encountered; if a
 pragma is not supported by a compiler pass it should be ignored and preserved
-intact for future passes.  Ideally, pragmas should be considered global and
-immutable; avoiding stateful interactions is recommended to prevent unexpected
-behaviors between source files.
+intact for future passes.  Pragmas should be avoid stateful or positional
+interactions to avoid unexpected behaviors between included source files. If the
+position is relevant to a pragma, an annotation should be used instead.
 
 Pragmas are useful for extending OpenQASM functionality that is not described in
-this specification, such as adding noise operations.
+this specification, such as adding directives to a simulator.
 
 \*Note: The following examples are simply possible implementations, this
 specification does not define any pragmas. Please consult your tool's
@@ -30,8 +31,7 @@ documentation for supported pragmas.
 .. code-block:: c
    :force:
 
-   rx(0.15) q;
-   pragma noise bit_flip(0.1)
+   pragma simulator noise model "qpu1.noise"
 
 Pragmas can also be used to specify system-level information or assertions for
 the entire circuit.
@@ -54,9 +54,8 @@ Annotations
 -----------
 
 Annotations can be added to supply additional information to the following
-OpenQASM statement. These annotations will apply to the subsequent declaration,
-box, or single line of code. Annotations will start with a ``@`` symbol, have an
-identifying keyword and continue to the end of the line.
+OpenQASM ``statement`` as defined in the grammar. Annotations will start with a
+``@`` symbol, have an identifying keyword and continue to the end of the line.
 
 Multiple annotations may be added to a single statement. No ordering or
 interaction between annotations are prescribed by this specification.

--- a/source/language/directives.rst
+++ b/source/language/directives.rst
@@ -12,12 +12,13 @@ Pragmas
 -------
 
 Pragma directives start with ``pragma`` and continue to the end of line. The
-``#pragma`` syntax is also accepted for reverse compatibility. Pragmas should be
-processed as soon as they are encountered; if a pragma is not supported by a
-compiler pass it should be ignored and preserved intact for future passes.
-Ideally, pragmas should be considered global and immutable; avoiding stateful
-interactions is recommended to prevent unexpected behaviors between source
-files.
+text after ``pragma`` is a single string, and parsing is left to the specific
+implementation. The ``#pragma`` syntax is deprecated, but is accepted for
+compatibility. Pragmas should be processed as soon as they are encountered; if a
+pragma is not supported by a compiler pass it should be ignored and preserved
+intact for future passes.  Ideally, pragmas should be considered global and
+immutable; avoiding stateful interactions is recommended to prevent unexpected
+behaviors between source files.
 
 Pragmas are useful for extending OpenQASM functionality that is not described in
 this specification, such as adding noise operations.
@@ -57,6 +58,9 @@ OpenQASM statement. These annotations will apply to the subsequent declaration,
 box, or single line of code. Annotations will start with a ``@`` symbol, have an
 identifying keyword and continue to the end of the line.
 
+Multiple annotations may be added to a single statement. No ordering or
+interaction between annotations are prescribed by this specification.
+
 \*Note: The following examples are simply possible implementations, this
 specification does not define any annotations. Please consult your tool's
 documentation for supported annotations.
@@ -78,8 +82,13 @@ documentation for supported annotations.
    @noswap
    box {
       rx(pi) q[0];
-      cnot q[0], q[1];
+      cnot q[0], q[3];
    }
+
+   // Apply multiple annotations
+   @crosstalk
+   @noise profile "gate_noise.qnf"
+   defcal noisy_gate $0 $1 { ... }
 
 
 Input/output


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Following up with textual changes for [#294](https://github.com/Qiskit/openqasm/issues/294). The initial PR is for discussion with the TSC; required grammar updates will be included once the textual changes are approved.

### Details and comments

This PR updates the [Directive](https://qiskit.github.io/openqasm/language/directives.html#directives) section to be more explicit about what pragmas are and how they should be used, including examples. A new directive type (Annotations) is also proposed to imply binding pragma-like behavior to a scoped area of code in a concise way.

#### Topics discussed and alternatives

Pre-processor macros (e.g., `#if`, `#endif`, `#define`) were discussed and rejected based on a desire to not add a pre-processor into OpenQASM implementions. This is largely to avoid issues with adding and specifying a pre-processor in the OpenQASM specification. We justified this by thinking of OpenQASM as an IR, not a human-written language; the pre-processing should be done in the native language that the human is writing and the OpenQASM should be
generated to match.

Scoping and precedence for pragmas was discussed and ultimately rejected as overly prescriptive. We offered examples and recommendations about how to use pragmas safely as global settings, and to avoid implementing stateful behavior,
but ultimately left the decision to the implementation. Annotations were added as a simplified mechanism for associating pragma-like behavior that was local to a piece of code.

Removing the leading hash symbol on `#pragma` was chosen for consistency with `include` not having it, and focusing on pragmas being native keywords in OpenQASM. It is a vestigial symbol from C/C++ and OpenQASM 2.0, but it is
redundant with a keyword (`#pragma ifdef foo` is awkward syntax). Since we are focused on making `pragma` a fully parsed member of OpenQASM, and no other keywords are prefixed with a symbol, it didn't make sense to keep it. Another
acceptable alternative would be to allow just `#` followed by text.

The decision to use `#pragma` in favor of `pragma` is undercut by the use of `@` as the marker for annotations (borrowed from Python and Java). The keyword `tag` is a reasonable alternative that is more inline with the previous decision.

Multi-line pragmas were discussed (see example below) and rejected as complicated to handle for naive OpenQASM scripts that could simply omit a single line. This does come at the cost of readability, but fits with the principle of
OpenQASM being generated instead of human written. 

    #pragma
        noise matrix [
            [1], [0],
            [0], [1im]
        ]
    #endpragma
