### PR TITLE
clarify subroutine parameters documentation

### DIFF
--- a/source/language/subroutines.rst
+++ b/source/language/subroutines.rst
@@ -2,13 +2,13 @@ Subroutines
 ===========
 
 Subroutines are declared using the statement ``def name(parameters) -> output_type { body }``.
-Zero or more quantum bits
-and classical values are passed to the subroutine by reference or name in ``qargs``.
-Classical types are passed by value in ``parameters``.
+The subroutine will define zero or more parameters as input, consisting of both quantum and classical arguments.
+Quantum bits and registers are passed in by reference or name, while classical types are passed in by value.
+All arguments are declared together with their type,
+for example ``qubit ancilla`` would define a quantum bit argument named ``ancilla``.
 The subroutines return up to one value of classical type, signified by the
 ``return`` keyword. If there is no return type, the empty ``return``
-keyword may be used to immediately exit from the subroutine. All arguments are declared together
-with their type, for example ``qubit ancilla`` would define a quantum bit argument named ``ancilla``.
+keyword may be used to immediately exit from the subroutine.
 Qubit declarations are not allowed within subroutines as they are global. A subroutine
 is invoked with the syntax ``name(parameters)`` and may be assigned to an ``output`` as
 needed via an assignment operator (``=``, ``+=``, etc).


### PR DESCRIPTION
<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->

### Summary

Clarifying some confusing/inaccurate wording on the interface for parameters for subroutines.

### Details and comments

I believe the existing reference to `qargs` is outdated. I don't believe classical values are passed in by reference to  qargs, especially since the next line talk about classical types being passed by value to parameters. Aggregated the parameter-related sentences for better readability.
