### PR TITLE
Correct type of arguments in QuantumGateDefinition

### DIFF
--- a/source/openqasm/openqasm3/ast.py
+++ b/source/openqasm/openqasm3/ast.py
@@ -183,7 +183,7 @@ class QuantumGateDefinition(Statement):
     """
 
     name: Identifier
-    arguments: List[ClassicalArgument]
+    arguments: List[Identifier]
     qubits: List[Identifier]
     body: List[QuantumStatement]
 


### PR DESCRIPTION
### Summary

The ANTLR to AST conversion was taking the type of the arguments to be
`Identifier`, but the AST hierarchy itself wanted them to be
`ClassicalArgument`.  The spec currently says that they are
"arbitrary-precision numerical types", which does not line up with
`ClassicalArgument` (which would include, e.g. `IntType`), and
`Identifier` is more correct for the current spec, though this may
change in the future.

<!--
⚠️ If you do not respect this template, your pull request will be closed.
⚠️ Your pull request title should be short detailed and understandable for all.
⚠️ If your pull request fixes an open issue, please link to the issue.

✅ I have added the tests to cover my changes.
✅ I have updated the documentation accordingly.
✅ I have read the CONTRIBUTING document.

Are you changing the specification? This PR needs to be approved by the TSC members.

Are you changing the grammar to adjust to the specification?

The specification is the source of truth and any grammar updates should also coincide with accepted specification updates in the same PR.

-->


### Details and comments

Fix #345 (the immediately actionable parts - the discussion touches on other on-going discussions, but those are orthogonal to #345 itself).
