### PR TITLE
Fix License link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -89,7 +89,7 @@ The OpenQASM project has a process for accepting changes to the language and mak
 
 ## License
 
-This project is licensed under the Apache License 2.0 - see the [LICENSE] file for details.
+This project is licensed under the Apache License 2.0 - see the [LICENSE](./LICENSE) file for details.
 
 
 ## Contributing


### PR DESCRIPTION
### Summary
This fixes the broken link in the readme file to the license file.


### Details and comments
N/A

